### PR TITLE
SW-93 modify reset password api & verify password api

### DIFF
--- a/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
+++ b/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
@@ -99,9 +99,9 @@ public class MembersApiController {
 
 //    @Hidden
     @Operation(summary = "비밀번호 변경", description = "비밀번호 재설정을 요청합니다.")
-    @PutMapping("/{userId}/password")
-    public ResponseEntity<?> changePw(@PathVariable("userId") String userId, @RequestBody MemberUpdateRequest memberUpdateRequest) {
-        return memberServiceImpl.updatePw(userId, memberUpdateRequest);
+    @PutMapping("/{loginId}/password")
+    public ResponseEntity<?> changePw(@PathVariable("loginId") String loginId, @RequestBody MemberUpdatePasswordRequest dto) {
+        return memberServiceImpl.updatePw(loginId, dto);
     }
 
 //    @Hidden
@@ -132,9 +132,9 @@ public class MembersApiController {
     }
 
     @Operation(summary = "내 비밀번호 검증(확인)", description = "이메일과 비밀번호 입력 시 비밀번호가 맞는지 확인")
-    @PostMapping("/{userId}/password")
-    public ResponseEntity<Boolean> isMyPw(@PathVariable("userId") String userId, @RequestBody MemberCheckPasswordRequest dto) {
-        return memberServiceImpl.isMyPassword(userId, dto);}
+    @PostMapping("/{loginId}/password")
+    public ResponseEntity<Boolean> isMyPw(@PathVariable("loginId") String loginId, @RequestBody MemberCheckPasswordRequest dto) {
+        return memberServiceImpl.isMyPassword(loginId, dto);}
 
     @Operation(summary = "로그아웃", description = "해당 유저의 토큰 정보가 db에서 삭제 됩니다.")
     @PostMapping("/{userId}/logout")

--- a/src/main/java/com/sweep/jaksim31/domain/members/Members.java
+++ b/src/main/java/com/sweep/jaksim31/domain/members/Members.java
@@ -95,16 +95,17 @@ public class Members {
     public void updateMember(MemberUpdateRequest dto, PasswordEncoder passwordEncoder) throws BizException {
 
         if(dto.getOldPassword() != null) {
-            // 비밀번호가 같지 않다면
-            if (!passwordEncoder.matches(dto.getOldPassword(), this.password)){
+            // 비밀번호가 같지 않다면 예외 처리
+            if (!passwordEncoder.matches(dto.getOldPassword(), this.password))
                 throw new BizException(MemberExceptionType.WRONG_PASSWORD);
-            }
+
             this.password = passwordEncoder.encode(dto.getNewPassword());
         }
         if(dto.getUsername() != null) this.username = dto.getUsername();
         if(dto.getProfileImage() != null) this.profileImage = dto.getProfileImage();
         this.updateDate = Instant.now();
     }
+
 
     public void remove(char delYn){
         this.delYn = delYn;

--- a/src/main/java/com/sweep/jaksim31/dto/member/MemberUpdatePasswordRequest.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/MemberUpdatePasswordRequest.java
@@ -1,0 +1,27 @@
+package com.sweep.jaksim31.dto.member;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * packageName :  com.sweep.jaksim31.dto.member
+ * fileName : MemberUpdatePasswordRequest
+ * author :  방근호
+ * date : 2023-01-16
+ * description : 사용자 패스워드 Update를 위한 DTO
+ * ===========================================================
+ * DATE                 AUTHOR                NOTE
+ * -----------------------------------------------------------
+ * 2023-01-16           방근호             최초 생성
+ *
+ */
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class MemberUpdatePasswordRequest {
+    private String newPassword;
+//    private List<String> authorities;
+
+}


### PR DESCRIPTION
[추가]
1. MemberUpdatePasswordRequest DTO 추가 (기존 MemberUpdateRequest와 분리)

[수정]
1. Member service updatePW 수정 (패스워드 검증 부분 제거)
2. 비밀번호 재설정 api, 비밀번호 검증 api Path vairable 변경 (userId -> loginId)
3. 비밀번호 검증 안되던 부분 오류 수정(Passwordencoder.matches method 사용)