### PR TITLE
SW-104 Feature/diary service test

### DIFF
--- a/src/main/java/com/sweep/jaksim31/controller/DiaryApiController.java
+++ b/src/main/java/com/sweep/jaksim31/controller/DiaryApiController.java
@@ -38,6 +38,7 @@ import java.util.Map;
  * 2023-01-17           김주현             사용자 일기 조회 Paging 추가
  * 2023-01-18           김주현             id data type 변경(ObjectId -> String) 및 일기 분석 method 명 수정
  * 2023-01-19           김주현             Return 타입 변경(Diary -> DiaryResponse)
+ * 2023-01-20           김주현             findDiary input 값에 userId 추가
 */
 /* TODO
     * 일기 등록 시 최근 날짜의 일기인 경우 사용자 recent_diaries에 넣어주기 -> Members Entity 수정 후 진행해야함
@@ -97,7 +98,7 @@ public class DiaryApiController {
     @Operation(summary = "개별 일기 조회", description = "일기ID로 하나의 일기를 조회합니다.")
     @GetMapping(value="{userId}/{diaryId}")
     public ResponseEntity<DiaryResponse> findDiary(@PathVariable String userId, @PathVariable String diaryId){
-        return diaryService.findDiary(diaryId);
+        return diaryService.findDiary(userId, diaryId);
     }
 
     // 사용자 일기 조회

--- a/src/main/java/com/sweep/jaksim31/controller/DiaryApiController.java
+++ b/src/main/java/com/sweep/jaksim31/controller/DiaryApiController.java
@@ -37,6 +37,7 @@ import java.util.Map;
  * 2023-01-17           김주현             감정 통계 추가
  * 2023-01-17           김주현             사용자 일기 조회 Paging 추가
  * 2023-01-18           김주현             id data type 변경(ObjectId -> String) 및 일기 분석 method 명 수정
+ * 2023-01-19           김주현             Return 타입 변경(Diary -> DiaryResponse)
 */
 /* TODO
     * 일기 등록 시 최근 날짜의 일기인 경우 사용자 recent_diaries에 넣어주기 -> Members Entity 수정 후 진행해야함
@@ -54,14 +55,14 @@ public class DiaryApiController {
     // 전체 일기 조회
     @Operation(summary = "전체 일기 조회", description = "모든 일기를 조회합니다.")
     @GetMapping(value = "")
-    public ResponseEntity<List<Diary>> allDiaries(){
+    public ResponseEntity<List<DiaryResponse>> allDiaries(){
         return diaryService.allDiaries();
     }
 
     // 일기 등록
     @Operation(summary = "일기 등록", description = "일기를 저장합니다.")
     @PostMapping(value = "")
-    public ResponseEntity<Diary> saveDiary(@Validated @RequestBody DiarySaveRequest diarySaveRequest){
+    public ResponseEntity<DiaryResponse> saveDiary(@Validated @RequestBody DiarySaveRequest diarySaveRequest){
         //확인
         // System.out.println("Diary dto = " + diaryDto.toString());
 
@@ -80,7 +81,7 @@ public class DiaryApiController {
     // 일기 수정
     @Operation(summary = "일기 수정", description = "일기를 수정합니다.")
     @PutMapping(value = "{diaryId}")
-    public ResponseEntity<Diary> updateDiary(@PathVariable String diaryId, @Validated @RequestBody DiarySaveRequest diarySaveRequest){
+    public ResponseEntity<DiaryResponse> updateDiary(@PathVariable String diaryId, @Validated @RequestBody DiarySaveRequest diarySaveRequest){
         System.out.printf("Diary ID \"%s\" Update%n",diaryId);
         return diaryService.updateDiary(diaryId, diarySaveRequest);
     }
@@ -95,7 +96,7 @@ public class DiaryApiController {
     // 개별 일기 조회
     @Operation(summary = "개별 일기 조회", description = "일기ID로 하나의 일기를 조회합니다.")
     @GetMapping(value="{userId}/{diaryId}")
-    public ResponseEntity<Diary> findDiary(@PathVariable String userId, @PathVariable String diaryId){
+    public ResponseEntity<DiaryResponse> findDiary(@PathVariable String userId, @PathVariable String diaryId){
         return diaryService.findDiary(diaryId);
     }
 

--- a/src/main/java/com/sweep/jaksim31/dto/diary/DiaryEmotionStaticsResponse.java
+++ b/src/main/java/com/sweep/jaksim31/dto/diary/DiaryEmotionStaticsResponse.java
@@ -22,4 +22,8 @@ import java.util.List;
 @AllArgsConstructor
 public class DiaryEmotionStaticsResponse {
     private List<DiaryEmotionStatics> emotionStatics;
+
+    public static DiaryEmotionStaticsResponse of(List<DiaryEmotionStatics> emotionStatics) {
+        return new DiaryEmotionStaticsResponse(emotionStatics);
+    }
 }

--- a/src/main/java/com/sweep/jaksim31/dto/diary/DiaryEmotionStaticsResponse.java
+++ b/src/main/java/com/sweep/jaksim31/dto/diary/DiaryEmotionStaticsResponse.java
@@ -2,6 +2,7 @@ package com.sweep.jaksim31.dto.diary;
 
 import lombok.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 /**
@@ -14,16 +15,18 @@ import java.util.List;
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-16           김주현             최초 생성
+ * 2023-01-20           김주현          startDate, endDate(조회기간) 추가
  */
-@Getter
-@Setter
 @Data
-@Builder
 @AllArgsConstructor
+@NoArgsConstructor
+@Builder
 public class DiaryEmotionStaticsResponse {
     private List<DiaryEmotionStatics> emotionStatics;
+    private LocalDate startDate;
+    private LocalDate endDate;
 
-    public static DiaryEmotionStaticsResponse of(List<DiaryEmotionStatics> emotionStatics) {
-        return new DiaryEmotionStaticsResponse(emotionStatics);
+    public static DiaryEmotionStaticsResponse of(List<DiaryEmotionStatics> emotionStatics, LocalDate startDate, LocalDate endDate) {
+        return new DiaryEmotionStaticsResponse(emotionStatics,startDate,endDate);
     }
 }

--- a/src/main/java/com/sweep/jaksim31/dto/diary/DiaryResponse.java
+++ b/src/main/java/com/sweep/jaksim31/dto/diary/DiaryResponse.java
@@ -6,39 +6,36 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.time.LocalDate;
 
 /**
  * packageName :  com.sweep.jaksim31.dto.diary
- * fileName : DiaryInfoDTO -> DiarySaveResponse
+ * fileName : DiaryResponse
  * author :  김주현
- * date : 2023-01-12
- * description :
+ * date : 2023-01-19
+ * description : 일기 정보 전체를 전달하는 DTO
  * ===========================================================
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
- * 2023-01-12                김주현             최초 생성
- * 2023-01-13                방근호             클래스 이름 변경
- * 2023-01-17                김주현             contents field 삭제
- * 2023-01-19                김주현             date -> diary date
+ * 2023-01-19           김주현             최초 생성
  */
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class DiaryInfoResponse {
+public class DiaryResponse {
     @Id
     private String diaryId;
     private String userId;
+    private String content;
     private LocalDate diaryDate;
     private LocalDate modifyDate;
     private String emotion;
     private String[] keywords;
     private String thumbnail;
 
-    public static DiaryInfoResponse of(Diary diary){
-        return new DiaryInfoResponse(diary.getId(), diary.getUserId(), diary.getDate().toLocalDate(), diary.getModifyDate().toLocalDate(), diary.getEmotion(), diary.getKeywords(), diary.getThumbnail());
+    public static DiaryResponse of(Diary diary){
+        return new DiaryResponse(diary.getId(), diary.getUserId(), diary.getContent(), diary.getDate().toLocalDate(), diary.getModifyDate().toLocalDate(), diary.getEmotion(), diary.getKeywords(), diary.getThumbnail());
     }
 }

--- a/src/main/java/com/sweep/jaksim31/dto/member/MemberInfoResponse.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/MemberInfoResponse.java
@@ -37,6 +37,6 @@ public class MemberInfoResponse {
     private int diaryTotal;
 
     public static MemberInfoResponse of(Members members) {
-        return new MemberInfoResponse(members.getId().toString(), members.getLoginId(), members.getUsername(), members.getProfileImage(), members.getRecentDiaries(), members.getDiaryTotal());
+        return new MemberInfoResponse(members.getId(), members.getLoginId(), members.getUsername(), members.getProfileImage(), members.getRecentDiaries(), members.getDiaryTotal());
     }
 }

--- a/src/main/java/com/sweep/jaksim31/dto/member/MemberSaveResponse.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/MemberSaveResponse.java
@@ -34,6 +34,6 @@ public class MemberSaveResponse {
     private String profileImage;
 
     public static MemberSaveResponse of(Members members) {
-        return new MemberSaveResponse(members.getId().toString(), members.getLoginId(), members.getUsername(), members.getProfileImage());
+        return new MemberSaveResponse(members.getId(), members.getLoginId(), members.getUsername(), members.getProfileImage());
     }
 }

--- a/src/main/java/com/sweep/jaksim31/exception/type/DiaryExceptionType.java
+++ b/src/main/java/com/sweep/jaksim31/exception/type/DiaryExceptionType.java
@@ -16,6 +16,7 @@ import org.springframework.http.HttpStatus;
  * 2023-01-11                김주현             최초 생성
  * 2023-01-12                김주현            NOT_FOUND_DIARY 추가
  * 2023-01-15                방근호            DELETE_NOT_FOUND_USER 추가
+ * 2023-01-20                김주현            NO_PERMISSION 추가
  */
 @Getter
 public enum DiaryExceptionType implements BaseExceptionType {
@@ -23,6 +24,7 @@ public enum DiaryExceptionType implements BaseExceptionType {
     NOT_FOUND_DIARY("NOT_FOUND_DIARY","일기를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     DUPLICATE_DIARY("DUPLICATE_DIARY", "이미 일기가 존재합니다.",HttpStatus.BAD_REQUEST),
     WRONG_DATE("WRONG_DATE", "잘못 된 날짜입니다.",HttpStatus.BAD_REQUEST),
+    NO_PERMISSION("NO_PERMISSION", "권한이 없습니다.",HttpStatus.BAD_REQUEST),
     // 삭제 메소드 수행 시 존재 하지 않을 경우 200 응답
     DELETE_NOT_FOUND_DIARY("ALREADY_NOT_EXIST_DIARY", "존재하지 않는 일기입니다.", HttpStatus.OK);
 

--- a/src/main/java/com/sweep/jaksim31/exception/type/DiaryExceptionType.java
+++ b/src/main/java/com/sweep/jaksim31/exception/type/DiaryExceptionType.java
@@ -24,7 +24,7 @@ public enum DiaryExceptionType implements BaseExceptionType {
     NOT_FOUND_DIARY("NOT_FOUND_DIARY","일기를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     DUPLICATE_DIARY("DUPLICATE_DIARY", "이미 일기가 존재합니다.",HttpStatus.BAD_REQUEST),
     WRONG_DATE("WRONG_DATE", "잘못 된 날짜입니다.",HttpStatus.BAD_REQUEST),
-    NO_PERMISSION("NO_PERMISSION", "권한이 없습니다.",HttpStatus.BAD_REQUEST),
+    NO_PERMISSION("NO_PERMISSION", "권한이 없습니다.",HttpStatus.FORBIDDEN),
     // 삭제 메소드 수행 시 존재 하지 않을 경우 200 응답
     DELETE_NOT_FOUND_DIARY("ALREADY_NOT_EXIST_DIARY", "존재하지 않는 일기입니다.", HttpStatus.OK);
 

--- a/src/main/java/com/sweep/jaksim31/service/DiaryService.java
+++ b/src/main/java/com/sweep/jaksim31/service/DiaryService.java
@@ -1,11 +1,7 @@
 package com.sweep.jaksim31.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.sweep.jaksim31.dto.diary.DiaryAnalysisRequest;
-import com.sweep.jaksim31.dto.diary.DiaryAnalysisResponse;
-import com.sweep.jaksim31.dto.diary.DiarySaveRequest;
-import com.sweep.jaksim31.dto.diary.DiaryInfoResponse;
-import com.sweep.jaksim31.domain.diary.Diary;
+import com.sweep.jaksim31.dto.diary.*;
 import org.json.simple.parser.ParseException;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
@@ -27,26 +23,27 @@ import java.util.Map;
  * 2023-01-12           방근호       analyzeDiary 메소드 추가
  * 2023-01-14           김주현         todayDiary 메소드 추가
  * 2023-01-17           김주현         findUserDiaries 메소드 수정
+ * 2023-01-19           김주현       Return 타입 변경(Diary -> DiaryResponse)
  */
 
 public interface DiaryService {
     // 일기 전체 조회
-    ResponseEntity<List<Diary>> allDiaries();
+    ResponseEntity<List<DiaryResponse>> allDiaries();
 
     // 사용자 일기 전체 조회
     ResponseEntity<Page<DiaryInfoResponse>> findUserDiaries(String userId, Map params);
 
     // 일기 생성
-    ResponseEntity<Diary> saveDiary(DiarySaveRequest diarySaveRequest);
+    ResponseEntity<DiaryResponse> saveDiary(DiarySaveRequest diarySaveRequest);
 
     // 일기 수정
-    ResponseEntity<Diary> updateDiary(String diaryId, DiarySaveRequest diarySaveRequest);
+    ResponseEntity<DiaryResponse> updateDiary(String diaryId, DiarySaveRequest diarySaveRequest);
 
     // 일기 삭제
     ResponseEntity<String> remove(String diaryId);
 
     // 일기 조회
-    ResponseEntity<Diary> findDiary(String diaryId);
+    ResponseEntity<DiaryResponse> findDiary(String diaryId);
 
     // 일기 검색
     ResponseEntity<Page<DiaryInfoResponse>> findDiaries(String userId, Map<String, Object> params);

--- a/src/main/java/com/sweep/jaksim31/service/DiaryService.java
+++ b/src/main/java/com/sweep/jaksim31/service/DiaryService.java
@@ -24,6 +24,7 @@ import java.util.Map;
  * 2023-01-14           김주현         todayDiary 메소드 추가
  * 2023-01-17           김주현         findUserDiaries 메소드 수정
  * 2023-01-19           김주현       Return 타입 변경(Diary -> DiaryResponse)
+ * 2023-01-20           김주현         findDiary 메소드 input값에 userId 추가
  */
 
 public interface DiaryService {
@@ -43,7 +44,7 @@ public interface DiaryService {
     ResponseEntity<String> remove(String diaryId);
 
     // 일기 조회
-    ResponseEntity<DiaryResponse> findDiary(String diaryId);
+    ResponseEntity<DiaryResponse> findDiary(String userId, String diaryId);
 
     // 일기 검색
     ResponseEntity<Page<DiaryInfoResponse>> findDiaries(String userId, Map<String, Object> params);

--- a/src/main/java/com/sweep/jaksim31/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/DiaryServiceImpl.java
@@ -168,6 +168,7 @@ public class DiaryServiceImpl implements DiaryService {
 
         Diary diary = diarySaveRequest.toEntity();
         // 썸네일 URL 추가
+        // TODO 썸네일 저장 부분 고려해보기. 아직 미완.
         diary.setThumbnail(DOWNLOAD_URL+"/" + diary.getUserId() + "/" + DATE_FORMATTER.format(ZonedDateTime.now()) + "_r_640x0_100_0_0.png");
         return new ResponseEntity<>(DiaryResponse.of(diaryRepository.save(diary))
                 , HttpStatus.CREATED);
@@ -295,6 +296,9 @@ public class DiaryServiceImpl implements DiaryService {
      * @throws JsonProcessingException Json processing 예외
      * @throws ParseException parsing 예외
      */
+    /** TODO
+     *   코드 리팩토링
+     */
     @Override
     public ResponseEntity<DiaryAnalysisResponse> analyzeDiary(DiaryAnalysisRequest diaryAnalysisRequest) throws JsonProcessingException, ParseException {
 
@@ -418,8 +422,6 @@ public class DiaryServiceImpl implements DiaryService {
         else{
             endDate = LocalDate.now().atTime(9,0);}
 
-        List<DiaryEmotionStatics> emotionStatics = null;
-
         // Aggregation 설정
         // filter
         MatchOperation matchOperation = Aggregation.match(
@@ -435,11 +437,12 @@ public class DiaryServiceImpl implements DiaryService {
         AggregationResults<DiaryEmotionStatics> aggregation = this.mongoTemplate.aggregate(Aggregation.newAggregation(matchOperation, groupOperation, projectionOperation),
                 Diary.class,
                 DiaryEmotionStatics.class);
-
+//        System.out.println("## aggregation : "+ aggregation.getRawResults());
         // 쿼리 실행 결과 중 Output class에 매핑 된 결과
-        emotionStatics = aggregation.getMappedResults();
+        List<DiaryEmotionStatics> emotionStatics = aggregation.getMappedResults();
+        DiaryEmotionStaticsResponse diaryEmotionStaticsResponse = DiaryEmotionStaticsResponse.of(emotionStatics);
 
-        return ResponseEntity.ok(new DiaryEmotionStaticsResponse(emotionStatics));
+        return ResponseEntity.ok(diaryEmotionStaticsResponse);
     }
 
 }

--- a/src/main/java/com/sweep/jaksim31/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/MemberServiceImpl.java
@@ -280,7 +280,7 @@ public class MemberServiceImpl implements MemberService {
         // 작성 된 일기가 있다면 diary_id, 없으면 ""
         String todayDiaryId = "";
         if(todayDiary != null)
-            todayDiaryId = todayDiary.getId().toString();
+            todayDiaryId = todayDiary.getId();
         // 만료 시간을 당일 23:59:59로 설정
         long expTime = LocalTime.of(23,59,59).toSecondOfDay() - LocalTime.now().minusHours(9).toSecondOfDay();
         // check

--- a/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
@@ -55,6 +55,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-17           김주현             최초 생성
+ * 2023-01-19           김주현             Return 타입 변경(Diary -> DiaryResponse)
  */
 
 @WebMvcTest(controllers = DiaryApiController.class)
@@ -96,10 +97,10 @@ public class DiaryApiControllerTest  {
             LocalDate date = LocalDate.of(2023, 1, 18);
             //given
             given(diaryService.saveDiary(any()))
-                    .willReturn(ResponseEntity.ok(Diary.builder()
+                    .willReturn(ResponseEntity.ok(DiaryResponse.builder()
                             .userId("63c0cb6f30dc3d547e3b88bb")
                             .content("contents")
-                            .date(date)
+                            .diaryDate(date)
                             .emotion("happy")
                             .keywords(keywords)
                             .thumbnail("thumbnail")
@@ -210,7 +211,7 @@ public class DiaryApiControllerTest  {
             List<DiaryInfoResponse> diaryInfoResponses = List.of(DiaryInfoResponse.builder()
                     .diaryId("diaryId")
                     .userId("userId")
-                    .date(date)
+                    .diaryDate(date)
                     .modifyDate(LocalDate.now())
                     .emotion("happy")
                     .keywords(keywords)
@@ -247,7 +248,7 @@ public class DiaryApiControllerTest  {
             List<DiaryInfoResponse> diaryInfoResponses = List.of(DiaryInfoResponse.builder()
                     .diaryId("diaryId")
                     .userId("userId")
-                    .date(date)
+                    .diaryDate(date)
                     .modifyDate(LocalDate.now())
                     .emotion("happy")
                     .keywords(keywords)
@@ -286,13 +287,13 @@ public class DiaryApiControllerTest  {
             //given
             given(diaryService.updateDiary(any(), any()))
                     .willReturn(ResponseEntity.ok(
-                            new Diary("diaryId", DiarySaveRequest.builder().userId("userId")
+                            DiaryResponse.of(new Diary("diaryId", DiarySaveRequest.builder().userId("userId")
                                     .content("contents")
                                     .date(date)
                                     .emotion("happy")
                                     .keywords(keywords)
                                     .thumbnail("thumbnail")
-                                    .build())));
+                                    .build()))));
 
             //when
             DiarySaveRequest diarySaveRequest = new DiarySaveRequest("userId", "contents", date, "happy", keywords,"thumbnail");

--- a/src/test/java/com/sweep/jaksim31/service/impl/DiaryServiceImplTest.java
+++ b/src/test/java/com/sweep/jaksim31/service/impl/DiaryServiceImplTest.java
@@ -1,0 +1,497 @@
+package com.sweep.jaksim31.service.impl;
+
+import com.sweep.jaksim31.controller.feign.EmotionAnalysisFeign;
+import com.sweep.jaksim31.domain.diary.Diary;
+import com.sweep.jaksim31.domain.diary.DiaryRepository;
+import com.sweep.jaksim31.domain.members.MemberRepository;
+import com.sweep.jaksim31.domain.members.Members;
+import com.sweep.jaksim31.dto.diary.*;
+import com.sweep.jaksim31.exception.BizException;
+import com.sweep.jaksim31.exception.type.DiaryExceptionType;
+import com.sweep.jaksim31.exception.type.MemberExceptionType;
+import org.bson.Document;
+import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.*;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.AggregationResults;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.time.LocalDate;
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * packageName :  com.sweep.jaksim31.service.impl
+ * fileName : DiaryServiceImplTest
+ * author :  김주현
+ * date : 2023-01-19
+ * description : Diary Service Test
+ * ===========================================================
+ * DATE                 AUTHOR                NOTE
+ * -----------------------------------------------------------
+ * 2023-01-19           김주현             최초 생성
+ */
+@ExtendWith(MockitoExtension.class)
+@WithMockUser(username = "username", password = "password", roles = "ROLE_USER")
+
+public class DiaryServiceImplTest {
+    @InjectMocks
+    private DiaryServiceImpl diaryService;
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private DiaryRepository diaryRepository;
+    @Mock
+    private MongoTemplate mongoTemplate;
+    @Mock
+    private EmotionAnalysisFeign emotionAnalysisFeign;
+
+    private static MockedStatic<DiaryResponse> diaryResponse;
+    private static MockedStatic<DiaryInfoResponse> diaryInfoResponse;
+    private static MockedStatic<DiaryEmotionStaticsResponse> diaryEmotionStaticsResponse;
+    private static MockedStatic<Diary> diaryMockedStatic;
+    private static MockedStatic<PageableExecutionUtils> pageableExecutionUtils;
+    private static MockedStatic<Page> pageMockedStatic;
+
+    private static DiarySaveRequest diarySaveRequest;
+    private static DiaryAnalysisRequest diaryAnalysisRequest;
+    private static DiaryThumbnailRequest diaryThumbnailRequest;
+
+    private static String[] keywords;
+    private static LocalDate diaryDate;
+
+    @BeforeAll
+    public static void setup(){
+        keywords = new String[]{"happy"};
+        diaryDate = LocalDate.of(2023, 1, 7);
+
+        diaryResponse = mockStatic(DiaryResponse.class);
+        diaryInfoResponse = mockStatic(DiaryInfoResponse.class);
+        pageableExecutionUtils = mockStatic(PageableExecutionUtils.class);
+        pageMockedStatic = mockStatic(Page.class);
+        diaryEmotionStaticsResponse = mockStatic(DiaryEmotionStaticsResponse.class);
+
+        diarySaveRequest = DiarySaveRequest.builder()
+                .userId("userId")
+                .content("testContent")
+                .date(diaryDate)
+                .emotion("emotion")
+                .keywords(keywords)
+                .thumbnail("thumbnail")
+                .build();
+
+//        diaryAnalysisRequest.setSentences(List.of("testSentence","testSentence2"));
+//        diaryAnalysisRequest.setLang("en");
+    }
+    @AfterAll
+    public static void finish(){
+        diaryResponse.close();
+        diaryInfoResponse.close();
+    }
+    /** TODO
+     * 일기 저장 Service 구현 완료 후 Test 짜기
+     */
+//    @Nested
+//    @DisplayName("일기 저장 서비스")
+//    class saveDiary{
+//        @Test
+//        @DisplayName("정상인 경우")
+//        void saveDiary(){
+//            // given
+//            Diary diary = diarySaveRequest.toEntity();
+//
+//
+//            // when
+//
+//            // then
+//        }
+//    }
+    @Nested
+    @DisplayName("일기 수정 서비스")
+    class updateDiary{
+        String diaryId = "diaryId";
+        String userId = "userId";
+
+        @Test
+        @DisplayName("[정상]일기 수정 성공_일기 존재, 회원 존재")
+        void updateDiary(){
+            // given
+            Diary updatedDiary = new Diary(diaryId, diarySaveRequest);
+            assert updatedDiary != null;
+            DiaryResponse diaryResponse = new DiaryResponse(diaryId, userId, "testContext", diaryDate, LocalDate.now(), "emotion", keywords, "thumbnail");
+            // 일기가 존재하고
+            given(diaryRepository.findById(diaryId))
+                    .willReturn(Optional.of(updatedDiary));
+            // 사용자가 존재할 때
+            given(memberRepository.findById(userId))
+                    .willReturn(Optional.of(Members.builder().build()));
+            // 일기 저장 시 Diary 리턴
+            given(diaryRepository.save(any()))
+                    .willReturn(updatedDiary);
+            // DiaryResponse 응답.
+            given(DiaryResponse.of(updatedDiary))
+                    .willReturn(diaryResponse);
+
+            // when
+            ResponseEntity<DiaryResponse> result = diaryService.updateDiary(diaryId, diarySaveRequest);
+
+            // then
+            DiaryResponse expected = result.getBody();
+            assert expected != null;
+            assertEquals(expected.getUserId(), diarySaveRequest.getUserId());
+            assertEquals(expected.getDiaryDate(), diarySaveRequest.getDate());
+            assertEquals(expected.getModifyDate(), LocalDate.now());
+
+            verify(diaryRepository, times(1)).findById(diaryId);
+            verify(memberRepository, times(1)).findById(userId);
+            verify(diaryRepository, times(1)).save(any());
+        }
+        @Test
+        @DisplayName("[예외]일기가 존재하지 않을 때, 저장 X")
+        void failUpdateDiaryNotFoundDiary(){
+            // given
+            Diary updatedDiary = new Diary(diaryId, diarySaveRequest);
+            assert updatedDiary != null;
+            given(diaryRepository.findById(any()))
+                    .willThrow(new BizException(DiaryExceptionType.NOT_FOUND_DIARY));
+
+            // when
+            // then
+            assertThrows(BizException.class, () -> diaryService.updateDiary(diaryId, diarySaveRequest));
+            verify(diaryRepository, never()).save(updatedDiary);
+        }
+        @Test
+        @DisplayName("[예외]사용자가 존재하지 않을 때, 저장 X")
+        void failUpdateDiaryNotFoundUser(){
+            // given
+            Diary updatedDiary = new Diary(diaryId, diarySaveRequest);
+            assert updatedDiary != null;
+            given(diaryRepository.findById(any()))
+                    .willReturn(Optional.of(updatedDiary));
+            given(memberRepository.findById(any()))
+                    .willThrow(new BizException(MemberExceptionType.NOT_FOUND_USER));
+
+            // when
+            // then
+            assertThrows(BizException.class, () -> diaryService.updateDiary(diaryId, diarySaveRequest));
+            verify(diaryRepository, never()).save(updatedDiary);
+        }
+    }
+
+    @Nested
+    @DisplayName("일기 삭제 서비스")
+    class removeDiary{
+        String diaryId = "diaryId";
+        @Test
+        @DisplayName("[정상]일기 삭제 성공")
+        void removeDiary(){
+            // given
+            Diary diary = new Diary(diaryId, diarySaveRequest);
+            // 삭제하려고 하는 일기가 존재함
+            given(diaryRepository.findById(diaryId))
+                    .willReturn(Optional.of(diary));
+
+            // when
+            String result = diaryService.remove(diaryId).getBody();
+
+            // then
+            assertEquals(result, diaryId);
+
+            verify(diaryRepository, times(1)).findById(diaryId);
+            verify(diaryRepository, times(1)).delete(diary);
+        }
+        @Test
+        @DisplayName("[예외]일기가 존재하지 않을 때")
+        void failUpdateDiaryNotFoundDiary(){
+            // given
+            given(diaryRepository.findById(diaryId))
+                    .willReturn(Optional.empty());
+
+            // when
+            // then
+            assertThrows(BizException.class, () -> diaryService.remove(diaryId));
+            verify(diaryRepository, never()).delete(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("개별 일기 조회 서비스")
+    class findDiary{
+        String diaryId = "diaryId";
+        @Test
+        @DisplayName("[정상]일기 조회 성공")
+        void findDiary(){
+            // given
+            Diary diary = new Diary(diaryId, diarySaveRequest);
+            DiaryResponse diaryResponse = new DiaryResponse(diaryId,"userId", "testContext", diaryDate, LocalDate.now(), "emotion", keywords, "thumbnail");
+
+            given(diaryRepository.findById(diaryId))
+                    .willReturn(Optional.of(diary));
+            given(DiaryResponse.of(diary))
+                    .willReturn(diaryResponse);
+
+            // when
+            ResponseEntity<DiaryResponse> result = diaryService.findDiary(diaryId);
+
+            // then
+            DiaryResponse expected = result.getBody();
+            assert expected != null;
+            assertEquals(expected.getDiaryId(), diaryResponse.getDiaryId());
+            assertEquals(expected.getDiaryDate(), diaryResponse.getDiaryDate());
+            assertEquals(expected.getUserId(), diaryResponse.getUserId());
+            verify(diaryRepository, times(1)).findById(diaryId);
+        }
+        @Test
+        @DisplayName("[예외]일기가 존재하지 않을 때")
+        void failFindDiaryNotFoundDiary(){
+            // given
+            given(diaryRepository.findById(diaryId))
+//                    .willThrow(new BizException(DiaryExceptionType.NOT_FOUND_DIARY));
+                    .willReturn(Optional.empty()); // 알아서 exception에 걸림
+
+            // when
+            // then
+            assertThrows(BizException.class, () -> diaryService.findDiary(diaryId));
+            verify(diaryRepository, times(1)).findById(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("사용자 일기 조회 서비스")
+    class findUserDiary{
+        String userId = "userId";
+
+        @Test
+        @DisplayName("[정상]사용자 일기 조회 성공_page,size,sort")
+        void findUserDiaryByPageSizeSort(){
+            // given
+            Diary diary = diarySaveRequest.toEntity();
+            DiaryInfoResponse diaryInfoResponse = new DiaryInfoResponse("diaryId", userId, diaryDate, LocalDate.now(), "emotion", keywords, "thumbnail");
+            List<DiaryInfoResponse> diaryInfoResponses = List.of(diaryInfoResponse);
+
+            Map<String, String> param = new HashMap<>();
+            param.put("page", "0");
+            param.put("size","1");
+            param.put("sort","asc");
+
+            Pageable pageable = PageRequest.of(0, 1, Sort.by(Sort.Direction.ASC, "date"));
+            Page<Object> page = new PageImpl(diaryInfoResponses, pageable, 1);
+
+            given(memberRepository.findById(userId))
+                    .willReturn(Optional.of(Members.builder().build()));
+            given(mongoTemplate.find(any(),any(),any()))
+                    .willReturn(List.of(diary));
+            given(PageableExecutionUtils.getPage(any(),any(),any()))
+                    .willReturn(page);
+
+            // when
+            ResponseEntity<Page<DiaryInfoResponse>> result = diaryService.findUserDiaries(userId,param);
+
+            // then
+            Page<DiaryInfoResponse> expected = result.getBody();
+            assert expected != null;
+            assertEquals(expected.getPageable(), pageable);
+            assertEquals(expected.getSize(), page.getSize());
+            assertEquals(expected.getContent(), diaryInfoResponses);
+
+            verify(memberRepository, times(1)).findById(userId);
+            verify(mongoTemplate, times(1)).find(any(),any(),any());
+        }
+        @Test
+        @DisplayName("[정상]사용자 일기 조회 성공_page,size")
+        void findUserDiaryByPageSize(){
+            // given
+            Diary diary = diarySaveRequest.toEntity();
+            DiaryInfoResponse diaryInfoResponse = new DiaryInfoResponse("diaryId", userId, diaryDate, LocalDate.now(), "emotion", keywords, "thumbnail");
+            List<DiaryInfoResponse> diaryInfoResponses = List.of(diaryInfoResponse);
+
+            Map<String, String> param = new HashMap<>();
+            param.put("page", "0");
+            param.put("size","1");
+
+            // Input으로 입력되는 값이 없을 경우, sort default value = "date", DESC
+            Pageable pageable = PageRequest.of(0, 1, Sort.by(Sort.Direction.DESC, "date"));
+            Page<Object> page = new PageImpl(diaryInfoResponses, pageable, 1);
+
+            given(memberRepository.findById(userId))
+                    .willReturn(Optional.of(Members.builder().build()));
+            given(mongoTemplate.find(any(),any(),any()))
+                    .willReturn(List.of(diary));
+            given(PageableExecutionUtils.getPage(any(),any(),any()))
+                    .willReturn(page);
+
+            // when
+            ResponseEntity<Page<DiaryInfoResponse>> result = diaryService.findUserDiaries(userId,param);
+
+            // then
+            Page<DiaryInfoResponse> expected = result.getBody();
+            assert expected != null;
+            assertEquals(expected.getPageable(), pageable);
+            assertEquals(expected.getSize(), page.getSize());
+            assertEquals(expected.getSort(), page.getSort());
+            assertEquals(expected.getContent(), diaryInfoResponses);
+
+            verify(memberRepository, times(1)).findById(userId);
+            verify(mongoTemplate, times(1)).find(any(),any(),any());
+        }
+        @Test
+        @DisplayName("[정상]사용자 일기 조회 성공_page")
+        void findUserDiaryByPage(){
+            // given
+            Diary diary = diarySaveRequest.toEntity();
+            DiaryInfoResponse diaryInfoResponse = new DiaryInfoResponse("diaryId", userId, diaryDate, LocalDate.now(), "emotion", keywords, "thumbnail");
+            List<DiaryInfoResponse> diaryInfoResponses = List.of(diaryInfoResponse);
+
+            Map<String, String> param = new HashMap<>();
+            param.put("page", "0");
+            // Input으로 입력되는 값이 없을 경우, size default value = 9, sort default value = "date", DESC
+            Pageable pageable = PageRequest.of(0, 9, Sort.by(Sort.Direction.DESC, "date"));
+            Page<Object> page = new PageImpl(diaryInfoResponses, pageable, 1);
+
+            given(memberRepository.findById(userId))
+                    .willReturn(Optional.of(Members.builder().build()));
+            given(mongoTemplate.find(any(),any(),any()))
+                    .willReturn(List.of(diary));
+            given(PageableExecutionUtils.getPage(any(),any(),any()))
+                    .willReturn(page);
+
+            // when
+            ResponseEntity<Page<DiaryInfoResponse>> result = diaryService.findUserDiaries(userId,param);
+
+            // then
+            Page<DiaryInfoResponse> expected = result.getBody();
+            assert expected != null;
+            assertEquals(expected.getPageable(), pageable);
+            assertEquals(expected.getSize(), page.getSize());
+            assertEquals(expected.getSort(), page.getSort());
+            assertEquals(expected.getContent(), diaryInfoResponses);
+
+            verify(memberRepository, times(1)).findById(userId);
+            verify(mongoTemplate, times(1)).find(any(),any(),any());
+        }
+        @Test
+        @DisplayName("[정상]사용자 일기 조회 성공_no params")
+        void findUserDiary(){
+            // given
+            Diary diary = diarySaveRequest.toEntity();
+            DiaryInfoResponse diaryInfoResponse = new DiaryInfoResponse("diaryId", userId, diaryDate, LocalDate.now(), "emotion", keywords, "thumbnail");
+            List<DiaryInfoResponse> diaryInfoResponses = List.of(diaryInfoResponse);
+
+            Map<String, String> param = new HashMap<>();
+            // page default value = 0, size default value = 9, sort default value = "date", DESC
+            Pageable pageable = PageRequest.of(0, 9, Sort.by(Sort.Direction.DESC, "date"));
+            Page<Object> page = new PageImpl(diaryInfoResponses, pageable, 1);
+
+            given(memberRepository.findById(userId))
+                    .willReturn(Optional.of(Members.builder().build()));
+            given(mongoTemplate.find(any(),any(),any()))
+                    .willReturn(List.of(diary));
+            given(PageableExecutionUtils.getPage(any(),any(),any()))
+                    .willReturn(page);
+
+            // when
+            ResponseEntity<Page<DiaryInfoResponse>> result = diaryService.findUserDiaries(userId,param);
+
+            // then
+            Page<DiaryInfoResponse> expected = result.getBody();
+            assert expected != null;
+            assertEquals(expected.getPageable(), pageable);
+            assertEquals(expected.getSize(), page.getSize());
+            assertEquals(expected.getSort(), page.getSort());
+            assertEquals(expected.getContent(), diaryInfoResponses);
+
+            verify(memberRepository, times(1)).findById(userId);
+            verify(mongoTemplate, times(1)).find(any(),any(),any());
+        }
+        @Test
+        @DisplayName("[예외]사용자가 존재하지 않을 때")
+        void failFindUserDiaryNotFoundUser(){
+            // given
+            Map<String, String> param = new HashMap<>();
+            given(memberRepository.findById(userId))
+                    .willReturn(Optional.empty());
+
+            // when
+            // then
+            assertThrows(BizException.class, () -> diaryService.findUserDiaries(userId, param));
+            verify(mongoTemplate, never()).find(any(),any(),any());
+        }
+    }
+
+    @Nested
+    @DisplayName("감정 통계 서비스")
+    class emotionStatics{
+        String userId = "userId";
+        @Test
+        @DisplayName("[정상]감정 통계 성공")
+        void emotionStatics(){
+            Diary diary = diarySaveRequest.toEntity();
+            DiaryEmotionStatics diaryEmotionStatics = new DiaryEmotionStatics("emotion", 1);
+            List<DiaryEmotionStatics> emotionStatics = List.of(diaryEmotionStatics);
+            DiaryEmotionStaticsResponse diaryEmotionStaticsResponse = new DiaryEmotionStaticsResponse(emotionStatics);
+
+            AggregationResults<Object> aggregation = new AggregationResults<Object>(Collections.singletonList(emotionStatics), new Document());
+            Map<String, Object> param = new HashMap<>();
+            param.put("startDate", "2023-01-01");
+            param.put("endDate","2023-01-20");
+
+            // given
+            given(memberRepository.findById(userId))
+                    .willReturn(Optional.of(Members.builder().build()));
+            given(mongoTemplate.aggregate(any(), (Class<?>) any(), any()))
+                    .willReturn(aggregation);
+            given(DiaryEmotionStaticsResponse.of(emotionStatics))
+                    .willReturn(diaryEmotionStaticsResponse);
+
+            // when
+            ResponseEntity<DiaryEmotionStaticsResponse> result = diaryService.emotionStatics(userId,param);
+
+            // then
+            DiaryEmotionStaticsResponse expected = result.getBody();
+//            assert expected != null;
+//            assertEquals(expected.getEmotionStatics().get(0).getEmotion(), emotionStatics.get(0).getEmotion());
+//            assertEquals(expected.getEmotionStatics().get(0).getCountEmotion(), emotionStatics.get(0).getCountEmotion());
+
+            verify(memberRepository, times(1)).findById(userId);
+            verify(mongoTemplate, times(1)).aggregate(any(), (Class<?>) any(), any());
+        }
+    }
+
+//    @Nested
+//    @DisplayName("일기 분석 서비스")
+//    class analyzeDiary{
+//        List<String> koreanKeywords = List.of("사과","키위","바나나");
+//        List<String> englishKeywords = List.of("apple","kiwi","banana");
+//        String koreanEmotion = "좋음";
+//        String englishEmotion = "good";
+//        @Test
+//        @DisplayName("정상인 경우")
+//        void analyzeDiary(){
+//            // given
+//            EmotionAnalysisRequest emotionAnalysisRequest = new EmotionAnalysisRequest(diaryAnalysisRequest.getSentences().get(0));
+//            ResponseEntity<JSONObject> emotionAnalysisResult = emotionAnalysisFeign.emotionAnalysis(emotionAnalysisRequest);
+//            given(emotionAnalysisFeign.emotionAnalysis(emotionAnalysisRequest));
+//            // when
+//
+//            // then
+//        }
+//    }
+    /** TODO
+     *
+     *   일기 분석
+     *   감정 통계 (수정 필요)
+     */
+
+}

--- a/src/test/java/com/sweep/jaksim31/service/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/sweep/jaksim31/service/impl/MemberServiceImplTest.java
@@ -1,23 +1,12 @@
 package com.sweep.jaksim31.service.impl;
 
-import com.sweep.jaksim31.auth.CustomLoginIdPasswordAuthToken;
-import com.sweep.jaksim31.auth.CustomUserDetailsService;
-import com.sweep.jaksim31.auth.TokenProvider;
-import com.sweep.jaksim31.auth.UsernamePasswordAuthenticationToken;
 import com.sweep.jaksim31.domain.diary.DiaryRepository;
 import com.sweep.jaksim31.domain.members.MemberRepository;
 import com.sweep.jaksim31.domain.members.Members;
-import com.sweep.jaksim31.domain.token.RefreshToken;
-import com.sweep.jaksim31.domain.token.RefreshTokenRepository;
-import com.sweep.jaksim31.dto.login.LoginRequest;
 import com.sweep.jaksim31.dto.member.*;
-import com.sweep.jaksim31.dto.token.TokenResponse;
 import com.sweep.jaksim31.exception.BizException;
 import com.sweep.jaksim31.exception.type.MemberExceptionType;
 import com.sweep.jaksim31.utils.RedirectionUtil;
-import jdk.nashorn.internal.parser.Token;
-import lombok.With;
-import org.bson.types.ObjectId;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -26,15 +15,9 @@ import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.test.context.support.WithMockUser;
 
-import java.lang.reflect.Member;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Optional;
@@ -237,7 +220,7 @@ class MemberServiceImplTest {
             MemberInfoResponse memberInfoResponse1 = new MemberInfoResponse(userId, "loginId", "username", "profileImage", null, 10);
             //given
 
-            given(memberRepository.findById(new ObjectId(userId)))
+            given(memberRepository.findById(userId))
                     .willReturn(Optional.of(members));
 
             given(MemberInfoResponse.of(members))
@@ -247,7 +230,7 @@ class MemberServiceImplTest {
             ResponseEntity<MemberInfoResponse> memberInfo = memberService.getMyInfo(userId);
             MemberInfoResponse res = memberInfo.getBody();
             //then
-            verify(memberRepository).findById(new ObjectId(userId));
+            verify(memberRepository).findById(userId);
             assert res != null;
             assertEquals(res.getUserId(), userId);
         }
@@ -258,12 +241,12 @@ class MemberServiceImplTest {
             String userId = "63c4f6cbeb0a310a89188df6";
 
             //given
-            given(memberRepository.findById(new ObjectId(userId)))
+            given(memberRepository.findById(userId))
                     .willReturn(Optional.empty());
 
             //when & then
             assertThrows(BizException.class, () -> memberService.getMyInfo(userId));
-            verify(memberRepository, times(1)).findById(new ObjectId(userId));
+            verify(memberRepository, times(1)).findById(userId);
 
         }
     }
@@ -331,7 +314,7 @@ class MemberServiceImplTest {
             Members members = memberSaveRequest.toMember(passwordEncoder, false);
             MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("username", "profileImage");
 
-            given(memberRepository.findById(new ObjectId(userId)))
+            given(memberRepository.findById(userId))
                     .willReturn(Optional.of(members));
 
             given(memberRepository.save(members))
@@ -342,7 +325,7 @@ class MemberServiceImplTest {
 
             //then
             assertEquals(res, "회원 정보가 정상적으로 변경되었습니다.");
-            verify(memberRepository, times(1)).findById(new ObjectId(userId));
+            verify(memberRepository, times(1)).findById(userId);
             verify(memberRepository, times(1)).save(members);
         }
 
@@ -353,12 +336,12 @@ class MemberServiceImplTest {
             MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("username", "profileImage");
             String userId = "63c4f6cbeb0a310a89188df6";
             Members members = memberSaveRequest.toMember(passwordEncoder, false);
-            given(memberRepository.findById(new ObjectId(userId)))
+            given(memberRepository.findById(userId))
                     .willReturn(Optional.empty());
 
             //when & then
             assertThrows(BizException.class, ()-> memberService.updateMemberInfo(userId, memberUpdateRequest));
-            verify(memberRepository, times(1)).findById(new ObjectId(userId));
+            verify(memberRepository, times(1)).findById(userId);
             verify(memberRepository, never()).save(members);
         }
 
@@ -457,7 +440,7 @@ class MemberServiceImplTest {
             given(redirectionUtil.getLocationHeader())
                     .willReturn(httpHeaders);
 
-            given(memberRepository.findById(new ObjectId(userId)))
+            given(memberRepository.findById(userId))
                     .willReturn(Optional.of(members));
 
             given(passwordEncoder.matches(any(), any()))
@@ -471,7 +454,7 @@ class MemberServiceImplTest {
 
             //then
             assertEquals(res, "정상적으로 회원탈퇴 작업이 처리되었습니다.");
-            verify(memberRepository, times(1)).findById(new ObjectId(userId));
+            verify(memberRepository, times(1)).findById(userId);
             verify(passwordEncoder, times(1)).encode(any());
             verify(passwordEncoder, times(1)).matches(any(), any());
 
@@ -481,7 +464,7 @@ class MemberServiceImplTest {
         @DisplayName("실패한 경우 - 회원 존재 X")
         void failure() {
             // given
-            given(memberRepository.findById(new ObjectId(userId)))
+            given(memberRepository.findById(userId))
                     .willReturn(Optional.empty());
 
             MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest(userId, "password");
@@ -500,7 +483,7 @@ class MemberServiceImplTest {
             Members members = memberSaveRequest.toMember(passwordEncoder, false);
 
 
-            given(memberRepository.findById(new ObjectId(userId)))
+            given(memberRepository.findById(userId))
                     .willReturn(Optional.of(members));
 
             given(passwordEncoder.matches(any(), any()))
@@ -514,7 +497,7 @@ class MemberServiceImplTest {
 
             // when & then
             assertThrows(BizException.class, () -> memberService.remove(userId, memberRemoveRequest));
-            verify(memberRepository, times(1)).findById(new ObjectId(userId));
+            verify(memberRepository, times(1)).findById(userId);
             verify(passwordEncoder, times(1)).encode(any());
             verify(passwordEncoder, times(1)).matches(any(), any());
         }

--- a/src/test/java/com/sweep/jaksim31/service/impl/MemberServiceImplTest.java
+++ b/src/test/java/com/sweep/jaksim31/service/impl/MemberServiceImplTest.java
@@ -28,6 +28,18 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 
+/**
+ * packageName :  com.sweep.jaksim31.service.impl
+ * fileName : MemberServiceImplTest
+ * author :  방근호
+ * date : 2023-01-17
+ * description : Member Service Test
+ * ===========================================================
+ * DATE                 AUTHOR                NOTE
+ * -----------------------------------------------------------
+ * 2023-01-17           방근호             최초 생성
+ */
+
 @ExtendWith(MockitoExtension.class)
 @WithMockUser(username = "usernmae", password = "password", roles = "ROLE_USER")
 class MemberServiceImplTest {


### PR DESCRIPTION
- modify `MemberServiceImplTest` 
> change ID data type from ObjectId to String
> add comments

- modify `DiaryApiController`
> add `userId` to input value of `findDiary`

- modify `DiaryApiControllerTest`
> add `findDiary` controller test
> change `date` field to `diaryDate`
> change `id` field to `diaryId`

- change response of services 
> Diary -> DiaryResponse
> `date` field -> `diaryDate` (DiaryInfoResponse, DiaryResponse)
> `Id` field -> `diaryId` (DiaryInfoResponse, DiaryResponse)
> DiaryEmotionStaticResponse : add static method `of` and `startDate`, `endDate` field

- add `DiaryServiceImplTest`
> 완료)일기 수정, 삭제, 개별 조회, 사용자 조회, 감정 통계
> 예정) 일기 저장, 일기 분석

- modify `DiaryServiceImpl`
> add TODO 
> add userId to input value of `findDiary`
> add confirmation that the diary to be searched is the user's diary to 'findDiary'

- add `NO_PERMISSION` exception type to `DiaryExceptionType`
> 본인의 일기가 아닌 다른 사람의 일기를 조회하고자 했을 때 발생할 예외 타입