### PR TITLE
SW-109 Feature/diary total

### DIFF
--- a/src/main/java/com/sweep/jaksim31/controller/DiaryApiController.java
+++ b/src/main/java/com/sweep/jaksim31/controller/DiaryApiController.java
@@ -39,6 +39,7 @@ import java.util.Map;
  * 2023-01-18           김주현             id data type 변경(ObjectId -> String) 및 일기 분석 method 명 수정
  * 2023-01-19           김주현             Return 타입 변경(Diary -> DiaryResponse)
  * 2023-01-20           김주현             findDiary input 값에 userId 추가
+ *                      김주현             일기 삭제 api path 및 input 값에 userId 추가
 */
 /* TODO
     * 일기 등록 시 최근 날짜의 일기인 경우 사용자 recent_diaries에 넣어주기 -> Members Entity 수정 후 진행해야함
@@ -64,18 +65,6 @@ public class DiaryApiController {
     @Operation(summary = "일기 등록", description = "일기를 저장합니다.")
     @PostMapping(value = "")
     public ResponseEntity<DiaryResponse> saveDiary(@Validated @RequestBody DiarySaveRequest diarySaveRequest){
-        //확인
-        // System.out.println("Diary dto = " + diaryDto.toString());
-
-        //사용자 current_diaries에 현재 작성한 다이어리 넣기
-//        String userId = diaryDto.getUserId();
-//        Members user = member.findUser(diaryDto.getUserId());
-//        List<Diary> diaries = user.getRecentDiaries();
-//
-//        user.setRecentDiaries(diaries);
-//        userService.updateUser(user);
-//        diaries.add(diary);
-
         return diaryService.saveDiary(diarySaveRequest);
     }
 
@@ -89,9 +78,9 @@ public class DiaryApiController {
 
     // 일기 삭제
     @Operation(summary = "일기 삭제", description = "일기를 삭제합니다.")
-    @DeleteMapping(value="{diaryId}")
-    public ResponseEntity<String> deleteDiary(@PathVariable String diaryId){
-        return diaryService.remove(diaryId);
+    @DeleteMapping(value="{userId}/{diaryId}")
+    public ResponseEntity<String> deleteDiary(@PathVariable String userId, @PathVariable String diaryId){
+        return diaryService.remove(userId, diaryId);
     }
 
     // 개별 일기 조회
@@ -104,7 +93,7 @@ public class DiaryApiController {
     // 사용자 일기 조회
     @Operation(summary = "사용자 일기 조회", description = "해당 사용자의 일기를 조회합니다. 조회 조건(Query parameter)이 없을 경우 해당 사용자의 전체 일기가 조회됩니다.")
     @GetMapping(value = "{userId}")
-    public ResponseEntity<Page<DiaryInfoResponse>> findUserDiary(@PathVariable String userId, @RequestParam String page, @RequestParam(required = false) Map<String, Object> params){
+    public ResponseEntity<Page<DiaryInfoResponse>> findUserDiary(@PathVariable String userId, @RequestParam(required = false) String page, @RequestParam(required = false) String size, @RequestParam(required = false) String sort, @RequestParam(required = false) Map<String, Object> params){
         if(params.containsKey("emotion") || params.containsKey("startDate") || params.containsKey("endDate")){
             // 페이징 및 정렬 외에 다른 조건이 있다면 ElasticSearch로 검색
             return diaryService.findDiaries(userId, params);

--- a/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
+++ b/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
@@ -47,9 +47,6 @@ public class MembersApiController {
     private final MemberServiceImpl memberServiceImpl;
     private final KaKaoMemberServiceImpl kaKaoMemberService;
 
-
-
-
     @GetMapping("/test")
     public String test(){
         return "OK";

--- a/src/main/java/com/sweep/jaksim31/service/DiaryService.java
+++ b/src/main/java/com/sweep/jaksim31/service/DiaryService.java
@@ -19,12 +19,13 @@ import java.util.Map;
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-09           김주현             최초 생성
- * 2023-01-12           김주현       Diary 정보 조회 Return형식을 DiaryInfoDTO로 변경
- * 2023-01-12           방근호       analyzeDiary 메소드 추가
- * 2023-01-14           김주현         todayDiary 메소드 추가
- * 2023-01-17           김주현         findUserDiaries 메소드 수정
- * 2023-01-19           김주현       Return 타입 변경(Diary -> DiaryResponse)
- * 2023-01-20           김주현         findDiary 메소드 input값에 userId 추가
+ * 2023-01-12           김주현             Diary 정보 조회 Return형식을 DiaryInfoDTO로 변경
+ * 2023-01-12           방근호             analyzeDiary 메소드 추가
+ * 2023-01-14           김주현             todayDiary 메소드 추가
+ * 2023-01-17           김주현             findUserDiaries 메소드 수정
+ * 2023-01-19           김주현             Return 타입 변경(Diary -> DiaryResponse)
+ * 2023-01-20           김주현             findDiary 메소드 input값에 userId 추가
+ *                      김주현             일기 삭제 service input 값에 userId 추가
  */
 
 public interface DiaryService {
@@ -41,7 +42,7 @@ public interface DiaryService {
     ResponseEntity<DiaryResponse> updateDiary(String diaryId, DiarySaveRequest diarySaveRequest);
 
     // 일기 삭제
-    ResponseEntity<String> remove(String diaryId);
+    ResponseEntity<String> remove(String userId,String diaryId);
 
     // 일기 조회
     ResponseEntity<DiaryResponse> findDiary(String userId, String diaryId);

--- a/src/main/java/com/sweep/jaksim31/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/DiaryServiceImpl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sweep.jaksim31.controller.feign.*;
 import com.sweep.jaksim31.controller.feign.config.UploadImageFeignConfig;
+import com.sweep.jaksim31.domain.members.Members;
 import com.sweep.jaksim31.dto.diary.*;
 import com.sweep.jaksim31.dto.tokakao.EmotionAnalysisRequest;
 import com.sweep.jaksim31.dto.tokakao.ExtractedKeywordResponse;
@@ -70,6 +71,8 @@ import java.util.stream.Collectors;
  * 2023-01-18           김주현             id data type 변경(ObjectId -> String) 및 예외 처리 추가
  * 2023-01-19           김주현             Return 타입 변경(Diary -> DiaryResponse)
  * 2023-01-20           김주현             findDiary input 값에 userId 추가 및 조회하고자 하는 diary가 사용자의 diary 인지 검증 추가
+ *                      김주현             일기 삭제 서비스 input 값에 userId 추가
+ *                      김주현             일기 삭제 및 생성 시 사용자 정보의 totalDiary 값 업데이트
  */
 /* TODO
     * 일기 조건 조회 MongoTemplate 사용해서 수정하기
@@ -113,15 +116,15 @@ public class DiaryServiceImpl implements DiaryService {
     // 사용자 id 전체 일기 조회
     public ResponseEntity<Page<DiaryInfoResponse>> findUserDiaries(String userId, Map params){
         // 사용자를 찾을 수 없을 때
-        memberRepository
+        Members user = memberRepository
                 .findById(userId)
                 .orElseThrow(()-> new BizException(MemberExceptionType.NOT_FOUND_USER));
         Pageable pageable;
-        // paging 설정 값이 비어있다면, 기본값(첫번째 페이지(0), size=9) 세팅
+        // paging 설정 값이 비어있다면, 기본값(첫번째 페이지(0), size=사용자 total 일기 수) 세팅
         if(!params.containsKey("page"))
             params.put("page", "0");
         if(!params.containsKey("size"))
-            params.put("size", "9");
+            params.put("size", user.getDiaryTotal()+"");
         // sort가 없으면 최신순(default), asc라고 오면 오래된 순
         if(params.containsKey("sort") && params.get("sort").toString().toLowerCase().equals("asc"))
             pageable = PageRequest.of(Integer.parseInt(params.get("page").toString()) , Integer.parseInt(params.get("size").toString()), Sort.by("date"));
@@ -157,7 +160,7 @@ public class DiaryServiceImpl implements DiaryService {
     @Override
     public ResponseEntity<DiaryResponse> saveDiary(DiarySaveRequest diarySaveRequest){
         // 사용자를 찾을 수 없을 때
-        memberRepository.findById(diarySaveRequest.getUserId())
+        Members user = memberRepository.findById(diarySaveRequest.getUserId())
                 .orElseThrow(()-> new BizException(MemberExceptionType.NOT_FOUND_USER));
         // 해당 날짜에 이미 등록 된 일기가 있을 때
         if(diaryRepository.findDiaryByUserIdAndDate(diarySaveRequest.getUserId(), diarySaveRequest.getDate().atTime(9,0)).isPresent())
@@ -166,10 +169,15 @@ public class DiaryServiceImpl implements DiaryService {
         if(diarySaveRequest.getDate().isAfter(ChronoLocalDate.from(LocalDate.now().atTime(11,59)))){
             throw new BizException(DiaryExceptionType.WRONG_DATE);
         }
+        // 사용자 정보의 total diary 정보 업데이트
+        user.setDiaryTotal(user.getDiaryTotal()+1);
+        memberRepository.save(user);
 
         Diary diary = diarySaveRequest.toEntity();
         // 썸네일 URL 추가
-        // TODO 썸네일 저장 부분 고려해보기. 아직 미완.
+        // TODO
+        //  * 썸네일 저장 부분 고려해보기. 아직 미완.
+        //  * 최근 일기 저장(recentDiaries) 고려해보기. 만약 한다고 하면 구현 필요.
         diary.setThumbnail(DOWNLOAD_URL+"/" + diary.getUserId() + "/" + DATE_FORMATTER.format(ZonedDateTime.now()) + "_r_640x0_100_0_0.png");
         return new ResponseEntity<>(DiaryResponse.of(diaryRepository.save(diary))
                 , HttpStatus.CREATED);
@@ -199,11 +207,22 @@ public class DiaryServiceImpl implements DiaryService {
 
     @Override
     // 일기 삭제
-    public ResponseEntity<String> remove(String diaryId) {
+    public ResponseEntity<String> remove(String userId, String diaryId) {
         Diary diary = diaryRepository
                 .findById(diaryId)
                 .orElseThrow(() -> new BizException(DiaryExceptionType.DELETE_NOT_FOUND_DIARY));
+
+        // 다른 사용자의 일기 삭제 요청시, NO_PERMISSION Exception
+        if(!diary.getUserId().equals(userId))
+            throw new BizException(DiaryExceptionType.NO_PERMISSION);
+
+        // 사용자 정보의 total diary 정보 업데이트
+        Members user = memberRepository.findById(userId)
+                .orElseThrow(()-> new BizException(MemberExceptionType.NOT_FOUND_USER));
+        user.setDiaryTotal(user.getDiaryTotal()-1);
+
         diaryRepository.delete(diary);
+        memberRepository.save(user);
         return ResponseEntity.ok(diary.getId());
     }
 
@@ -229,34 +248,53 @@ public class DiaryServiceImpl implements DiaryService {
     // 일기 검색, 조건 조회
     public ResponseEntity<Page<DiaryInfoResponse>> findDiaries(String userId, Map<String, Object> params){
         // TODO
-        //  * ElasticSearch로 검색하도록 구현
-//
-//        // Repository 방식
-//        List<DiaryInfoResponse> diaries;
-//        LocalDateTime start_date;
-//        LocalDateTime end_date;
-//        // 시간 조건 설정
-//        if(params.containsKey("startDate")){
-//            start_date = (LocalDate.parse(((String)params.get("startDate")))).minusDays(1).atTime(9,0);}
-//        else{
-//            start_date = LocalDate.of(1990, 1, 1).atTime(9, 0);}
-//        if(params.containsKey("endDate")){
-//            end_date = (LocalDate.parse(((String)params.get("endDate")))).plusDays(1).atTime(9,0);}
-//        else{
-//            end_date = LocalDate.now().plusDays(1).atTime(9,0);}
-//        // 조건으로 조회
-//        if(params.containsKey("emotion"))
-//            diaries = diaryRepository.findDiariesByUserIdAndEmotionAndDateBetweenOrderByDate(userId, (String) params.get("emotion"), start_date, end_date).stream()
-//                    .map(m -> new DiaryInfoResponse().of(m))
-//                    .collect(Collectors.toList());
-//        else
-//            diaries = diaryRepository.findDiariesByUserIdAndDateBetweenOrderByDate(userId, start_date, end_date).stream()
-//                    .map(m -> new DiaryInfoResponse().of(m))
-//                    .collect(Collectors.toList());
-//
-//        System.out.println("Diaries : " + diaries);
+        //  * ElasticSearch 연결 되면 elasticSerch 사용해서 검색하도록 수정
 
-        return ResponseEntity.ok(null);
+        //mongoTemplate 사용해서 일단 구현
+        // 사용자를 찾을 수 없을 때
+        memberRepository
+                .findById(userId)
+                .orElseThrow(() -> new BizException(MemberExceptionType.NOT_FOUND_USER));
+        Pageable pageable;
+        // paging 설정 값이 비어있다면, 기본값(첫번째 페이지(0), size=9) 세팅
+        if(!params.containsKey("page"))
+            params.put("page", "0");
+        if(!params.containsKey("size"))
+            params.put("size", "9");
+        // sort가 없으면 최신순(default), asc라고 오면 오래된 순
+        if(params.containsKey("sort") && params.get("sort").toString().toLowerCase().equals("asc"))
+            pageable = PageRequest.of(Integer.parseInt(params.get("page").toString()) , Integer.parseInt(params.get("size").toString()), Sort.by("date"));
+        else
+            pageable = PageRequest.of(Integer.parseInt(params.get("page").toString()) , Integer.parseInt(params.get("size").toString()), Sort.by(Sort.Direction.DESC, "date"));
+        // page size와 찾고자 하는 page의 번호 외에 다른 section들은 skip하여 빠르게 찾아갈 수 있도록 Query 객체를 설정한다.
+        Query query = new Query()
+                .with(pageable)
+                .skip(pageable.getPageSize() * pageable.getPageNumber())
+                .limit(pageable.getPageSize());
+        query.addCriteria(Criteria.where("userId").is(userId));
+
+        for(String i : params.keySet()){
+            if(i.equals("startDate")){
+                query.addCriteria(Criteria.where("date").gte(LocalDate.parse((params.get("startDate").toString())).atTime(9,0)));
+            }else if(i.equals("endDate")){
+                query.addCriteria(Criteria.where("date").lte(LocalDate.parse((params.get("endDate").toString())).atTime(9,0)));
+            }else if(i.equals("page") || i.equals("sort") || i.equals("size"))
+                continue;
+            else{
+                query.addCriteria(Criteria.where(i).is(params.get(i).toString()));
+            }
+        }
+        List<DiaryInfoResponse> diaries = mongoTemplate.find(query, Diary.class, "diary")
+                .stream()
+                .map(DiaryInfoResponse::of)
+                .collect(Collectors.toList());
+        // filtering 된 데이터, 페이징 정보, document 개수 정보로 Page 객체 생성
+        Page<DiaryInfoResponse> diaryPage = PageableExecutionUtils.getPage(
+                diaries,
+                pageable,
+                () -> mongoTemplate.count(query.skip(-1).limit(-1), Diary.class, "diary")
+        );
+        return ResponseEntity.ok(diaryPage);
     }
 
     /**

--- a/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
@@ -483,7 +483,7 @@ public class DiaryApiControllerTest  {
                     .willReturn(ResponseEntity.ok("diaryId"));
 
             //when
-            mockMvc.perform(delete("/v0/diaries/diaryId")
+            mockMvc.perform(delete("/v0/diaries/userId/diaryId")
                             .with(csrf()) //403 에러 방지
                     )
 
@@ -501,7 +501,7 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(DiaryExceptionType.DELETE_NOT_FOUND_DIARY));
 
             //when
-            mockMvc.perform(delete("/v0/diaries/diaryId")
+            mockMvc.perform(delete("/v0/diaries/userId/diaryId")
                             .with(csrf()) //403 에러 방지
                     )
 

--- a/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
@@ -59,6 +59,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * 2023-01-17           김주현             최초 생성
  * 2023-01-19           김주현             Return 타입 변경(Diary -> DiaryResponse)
  * 2023-01-20           김주현             개별 일기 조회 controller test 추가 및 DiaryResponse의 date -> diaryDate
+ *                      김주현             일기 삭제 service 수정으로 인한 test 코드 수정
  */
 
 @WebMvcTest(controllers = DiaryApiController.class)
@@ -478,7 +479,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[정상]일기 삭제 완료")
         public void removeDiary() throws Exception{
             //given
-            given(diaryService.remove(any()))
+            given(diaryService.remove(any(), any()))
                     .willReturn(ResponseEntity.ok("diaryId"));
 
             //when
@@ -496,7 +497,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[정상]일기 정보가 없을 때")
         public void removeDiaryNotFoundDiary() throws Exception{
             //given
-            given(diaryService.remove(any()))
+            given(diaryService.remove(any(), any()))
                     .willThrow(new BizException(DiaryExceptionType.DELETE_NOT_FOUND_DIARY));
 
             //when

--- a/src/test/java/com/sweep/jaksim31/service/impl/DiaryServiceImplTest.java
+++ b/src/test/java/com/sweep/jaksim31/service/impl/DiaryServiceImplTest.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.*;
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-19           김주현             최초 생성
+ * 2023-01-20           김주현             일기 삭제 service 수정으로 인한 test 수정
  */
 @ExtendWith(MockitoExtension.class)
 @WithMockUser(username = "username", password = "password", roles = "ROLE_USER")
@@ -198,6 +199,7 @@ public class DiaryServiceImplTest {
     @DisplayName("일기 삭제 서비스")
     class removeDiary{
         String diaryId = "diaryId";
+        String userId = "userId";
         @Test
         @DisplayName("[정상]일기 삭제 성공")
         void removeDiary(){
@@ -208,7 +210,7 @@ public class DiaryServiceImplTest {
                     .willReturn(Optional.of(diary));
 
             // when
-            String result = diaryService.remove(diaryId).getBody();
+            String result = diaryService.remove(userId, diaryId).getBody();
 
             // then
             assertEquals(result, diaryId);
@@ -225,7 +227,7 @@ public class DiaryServiceImplTest {
 
             // when
             // then
-            assertThrows(BizException.class, () -> diaryService.remove(diaryId));
+            assertThrows(BizException.class, () -> diaryService.remove(userId, diaryId));
             verify(diaryRepository, never()).delete(any());
         }
     }


### PR DESCRIPTION
- 일기 삭제 controller 경로 수정
  > v0/diaries/{diaryId} => v0/diaries/{userId}/{diaryId}
- DiaryApiControllerTest와 DiaryServiceImplTest 수정
  > 서비스 수정에 따른 테스트 코드 수정 및 예외 테스트 추가
- DiaryServiceImple 수정(이전 commit 수정 사항)
  > (`findUserDiaries`) page 설정 값이 없이 요청이 들어올 경우, page=0, size=(변경 전 9 ->)사용자의 diaryTotal 값(int)으로 default 설정 변경
  > (`remove`/`saveDiary`)일기 삭제, 생성 시 사용자 정보의 total diary 수 변경
  > (`remove`)다른 사용자의 일기 삭제 요청시 예외처리
  > (`findDiaries`)일기 검색(조건 조회) mongoTemplate 으로 구현(Test 용)
    - 이후 Elastic Search 연동 되면 Elastic Search로 검색하도록 설정.
    - Elastic Search 적용 후 비교해보는 것도 좋을 것.