### PR TITLE
SW-117 feat(diary): Modify login/logout api

### DIFF
--- a/src/main/java/com/sweep/jaksim31/auth/TokenProvider.java
+++ b/src/main/java/com/sweep/jaksim31/auth/TokenProvider.java
@@ -135,12 +135,11 @@ public class TokenProvider {
 //                .grantType(BEARER_TYPE)
 //                .build();
 //    }
-    public TokenResponse createTokenDTO(MemberInfoResponse memberInfoResponse, String accessToken, String refreshToken, String expTime) {
+    public TokenResponse createTokenDTO(String accessToken, String refreshToken, String expTime) {
         return TokenResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .expTime(expTime)
-                .memberInfoResponse(memberInfoResponse)
                 .grantType(BEARER_TYPE)
                 .build();
     }

--- a/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
+++ b/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
@@ -42,6 +42,7 @@ import java.net.URISyntaxException;
  * 2023-01-13           장건              카카오 로그인 추가
  * 2023-01-15           방근호             카카오 로그인 api 리팩토링 및 로그아웃 추가
  * 2023-01-25           방근호             getMyInfoByLoginId 제거
+ * 2023-01-27           김주현             자체 로그인, 로그아웃 응답 수정 redirect(3xx) => ok(200)
  */
 
 /* TODO
@@ -85,13 +86,8 @@ public class MembersApiController {
     @PostMapping("/login")
     public ResponseEntity<TokenResponse> login(
             @Validated @RequestBody LoginRequest loginRequest,
-            HttpServletResponse response, @RequestParam("redirectUri") String redirectUri) throws URISyntaxException {
-
-        // Redirect 주소 설정
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setLocation(new URI(redirectUri));
-
-        return new ResponseEntity<>(memberServiceImpl.login(loginRequest, response), httpHeaders, HttpStatus.SEE_OTHER);
+            HttpServletResponse response) throws URISyntaxException {
+        return ResponseEntity.ok(memberServiceImpl.login(loginRequest, response));
     }
 
     @Operation(summary = "카카오 로그인", description = "카카오 OAUTH를 이용하여 로그인 합니다.")
@@ -165,11 +161,7 @@ public class MembersApiController {
     @PostMapping("/logout")
     public ResponseEntity<String> logout(HttpServletRequest request, HttpServletResponse response) throws URISyntaxException {
 
-        URI redirectUri = new URI(logoutRedirectUrl);
-        HttpHeaders httpHeaders = new HttpHeaders();
-        httpHeaders.setLocation(redirectUri);
-
-        return new ResponseEntity<>(memberServiceImpl.logout(request, response), httpHeaders, HttpStatus.SEE_OTHER);
+        return ResponseEntity.ok(memberServiceImpl.logout(request, response));
     }
 
     // 아직 테스트 X -> 프론트 연결 후 테스트 진행

--- a/src/main/java/com/sweep/jaksim31/dto/token/TokenResponse.java
+++ b/src/main/java/com/sweep/jaksim31/dto/token/TokenResponse.java
@@ -14,6 +14,7 @@ import lombok.*;
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-13           방근호             최초 생성
+ * 2023-01-27           김주현             MemberInfoResponse 제거
  *
  */
 
@@ -22,8 +23,6 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class TokenResponse {
-    @JsonProperty("memberInfo")
-    private MemberInfoResponse memberInfoResponse;
     private String grantType;
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/com/sweep/jaksim31/service/impl/KaKaoMemberServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/KaKaoMemberServiceImpl.java
@@ -147,7 +147,7 @@ public class KaKaoMemberServiceImpl implements MemberService {
 
         CookieUtil.addSecureCookie(response, "todayDiaryId", Objects.nonNull(todayDiary) ? todayDiary.getId() : "", todayExpTime);
 
-        return tokenProvider.createTokenDTO(MemberInfoResponse.of(members), accessToken,refreshToken, expTime);
+        return tokenProvider.createTokenDTO(accessToken,refreshToken, expTime);
 
     }
 

--- a/src/main/java/com/sweep/jaksim31/utils/CookieUtil.java
+++ b/src/main/java/com/sweep/jaksim31/utils/CookieUtil.java
@@ -19,6 +19,7 @@ import java.util.Optional;
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-09           방근호             최초 생성
+ * 2023-01-27           김주현             path 추가
  */
 
 public class CookieUtil {
@@ -41,6 +42,7 @@ public class CookieUtil {
 
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .maxAge(maxAge)
+                .path("/")
                 .build();
 
 
@@ -62,6 +64,7 @@ public class CookieUtil {
     public static void addPublicCookie(HttpServletResponse response, String name, String value, int maxAge) {
 
         ResponseCookie cookie = ResponseCookie.from(name, value)
+                .path("/")
                 .build();
 
 

--- a/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
@@ -67,6 +67,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-17           방근호             최초 생성
+ * 2023-01-27           김주현             로그인 응답 코드 변경에 따른 test코드 수정
  */
 
 @WebMvcTest(controllers = MembersApiController.class)
@@ -148,7 +149,6 @@ class MembersApiControllerTest {
             //given
             given(memberService.login(any(), any()))
                     .willReturn(TokenResponse.builder()
-                            .memberInfoResponse(memberInfoResponse)
                             .grantType("USER_ROLE")
                             .accessToken("accessToken")
                             .refreshToken("refreshToken")
@@ -161,16 +161,13 @@ class MembersApiControllerTest {
 
             mockMvc.perform(post("/v0/members/login")
                             .with(csrf()) //403 에러 방지
-                            .param("redirectUri", "http://localhost:3000/")
                             .content(jsonRequest)
                             .contentType(MediaType.APPLICATION_JSON))
 
                     //then
-                    .andExpect(status().is3xxRedirection())
+                    .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(header().string("Location", "http://localhost:3000/"))
                     .andExpect(jsonPath("$.grantType", Matchers.is("USER_ROLE")))
-                    .andExpect(jsonPath("$.memberInfo.loginId", Matchers.is("loginId")))
                     .andExpect(jsonPath("$.accessToken", Matchers.is("accessToken")))
                     .andExpect(jsonPath("$.refreshToken", Matchers.is("refreshToken")))
                     .andExpect(jsonPath("$.expTime", Matchers.is("1000")))
@@ -212,7 +209,6 @@ class MembersApiControllerTest {
             //given
             given(memberService.reissue(any(), any()))
                     .willReturn(TokenResponse.builder()
-                            .memberInfoResponse(memberInfoResponse)
                             .grantType("USER_ROLE")
                             .accessToken("accessToken")
                             .refreshToken("refreshToken")
@@ -230,7 +226,6 @@ class MembersApiControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$.grantType", Matchers.is("USER_ROLE")))
-                    .andExpect(jsonPath("$.memberInfo.loginId", Matchers.is("loginId")))
                     .andExpect(jsonPath("$.accessToken", Matchers.is("accessToken")))
                     .andExpect(jsonPath("$.refreshToken", Matchers.is("refreshToken")))
                     .andExpect(jsonPath("$.expTime", Matchers.is("2000")))
@@ -600,8 +595,7 @@ class MembersApiControllerTest {
 
             mockMvc.perform(post("/v0/members/logout")
                             .with(csrf()))
-
-                    .andExpect(status().is3xxRedirection())
+                    .andExpect(status().isOk())
                     .andExpect(content().string("로그아웃 되었습니다."))
                     .andExpect(content().contentType("text/plain;charset=UTF-8"))
                     .andDo(MockMvcResultHandlers.print(System.out));


### PR DESCRIPTION
- 로그인, 로그아웃 응답 수정
  > - Redirect(3xx) => OK(200)
  > - 로그인, 로그아웃 시 userId 쿠키 설정 추가
  > - refresh token SecureCookie로 전달
  > - 이에 따른 MembersApiControllerTest 수정

- CookieUtil 수정 : `path` option 설정 추가

- TokenResponse 수정 : MemberInfoResponse 제거
  > TokenResponse, TokenProvider, MemberServiceImpl, KaKaoMemberServiceImpl, MembersApiControllerTest 수정