### PR TITLE
SW-116 feat(diary): add Diary Validator test and Member Validator test to Controller test

### DIFF
--- a/src/main/java/com/sweep/jaksim31/domain/members/Members.java
+++ b/src/main/java/com/sweep/jaksim31/domain/members/Members.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
  * 2023-01-11           김주현             field 수정
  * 2023-01-12           김주현             profilePhoto -> profileImage
  * 2023-01-19           방근호             updateTime 수정(9시간 추가)
+ * 2023-01-28           김주현             ""면 업데이트 하지 않도록 조건 추가
  */
 
 @Getter
@@ -96,8 +97,8 @@ public class Members {
 
     public void updateMember(MemberUpdateRequest dto) throws BizException {
 
-        if(dto.getUsername() != null) this.username = dto.getUsername();
-        if(dto.getProfileImage() != null) this.profileImage = dto.getProfileImage();
+        if(dto.getUsername() != null && !dto.getUsername().equals("")) this.username = dto.getUsername();
+        if(dto.getProfileImage() != null && !dto.getProfileImage().equals("")) this.profileImage = dto.getProfileImage();
 
         this.updateDate = Instant.now().plus(9, ChronoUnit.HOURS);
     }

--- a/src/main/java/com/sweep/jaksim31/dto/diary/validator/DiarySaveRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/diary/validator/DiarySaveRequestValidator.java
@@ -35,19 +35,19 @@ public class DiarySaveRequestValidator implements Validator {
         }
         DiarySaveRequest request = DiarySaveRequest.class.cast(target);
 
-        if(Objects.isNull(request.getUserId()))
+        if(Objects.isNull(request.getUserId()) || request.getUserId().length() == 0)
             throw new BizException(DiaryExceptionType.USER_ID_IS_NULL);
-        if(Objects.isNull(request.getContent()))
+        if(Objects.isNull(request.getContent()) || request.getContent().length() == 0)
             throw new BizException(DiaryExceptionType.CONTENT_IS_NULL);
         if(Objects.isNull(request.getDate()))
             throw new BizException(DiaryExceptionType.DIARY_DATE_IS_NULL);
         if(request.getDate().compareTo(ChronoLocalDate.from(LocalDateTime.now())) > 0)
             throw new BizException(DiaryExceptionType.WRONG_DATE);
-        if(Objects.isNull(request.getEmotion()))
+        if(Objects.isNull(request.getEmotion()) || request.getEmotion().length() == 0)
             throw new BizException(DiaryExceptionType.EMOTION_IS_NULL);
         if(Objects.isNull(request.getKeywords()) || request.getKeywords().length == 0)
             throw new BizException(DiaryExceptionType.KEYWORDS_IS_NULL);
-        if(Objects.isNull(request.getUserId()))
+        if(Objects.isNull(request.getThumbnail()) || request.getThumbnail().length() == 0)
             throw new BizException(DiaryExceptionType.THUMBNAIL_IS_NULL);
 
     }

--- a/src/main/java/com/sweep/jaksim31/dto/diary/validator/DiaryThumbnailRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/diary/validator/DiaryThumbnailRequestValidator.java
@@ -32,11 +32,11 @@ public class DiaryThumbnailRequestValidator implements Validator {
         }
         DiaryThumbnailRequest request = DiaryThumbnailRequest.class.cast(target);
 
-        if(Objects.isNull(request.getUserId()))
+        if(Objects.isNull(request.getUserId()) || request.getUserId().length() == 0)
             throw new BizException(DiaryExceptionType.USER_ID_IS_NULL);
-        if(Objects.isNull(request.getDiaryId()))
+        if(Objects.isNull(request.getDiaryId())|| request.getDiaryId().length() == 0)
             throw new BizException(DiaryExceptionType.DIARY_ID_IS_NULL);
-        if(Objects.isNull(request.getThumbnail()))
+        if(Objects.isNull(request.getThumbnail())|| request.getThumbnail().length() == 0)
             throw new BizException(DiaryExceptionType.THUMBNAIL_IS_NULL);
     }
 }

--- a/src/main/java/com/sweep/jaksim31/dto/login/validator/LoginRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/login/validator/LoginRequestValidator.java
@@ -31,9 +31,9 @@ public class LoginRequestValidator implements Validator {
             return;
         }
         LoginRequest request = LoginRequest.class.cast(target);
-        if(Objects.isNull(request.getLoginId()))
+        if(Objects.isNull(request.getLoginId())|| request.getLoginId().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_LOGIN_ID);
-        if(Objects.isNull(request.getPassword()))
+        if(Objects.isNull(request.getPassword())|| request.getPassword().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_PASSWORD);
 
     }

--- a/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberCheckLoginIdRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberCheckLoginIdRequestValidator.java
@@ -31,7 +31,7 @@ public class MemberCheckLoginIdRequestValidator implements Validator {
             return;
         }
         MemberCheckLoginIdRequest request = MemberCheckLoginIdRequest.class.cast(target);
-        if(Objects.isNull(request.getLoginId()))
+        if(Objects.isNull(request.getLoginId()) || request.getLoginId().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_LOGIN_ID);
 
 

--- a/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberCheckPasswordRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberCheckPasswordRequestValidator.java
@@ -31,7 +31,7 @@ public class MemberCheckPasswordRequestValidator implements Validator {
             return;
         }
         MemberCheckPasswordRequest request = MemberCheckPasswordRequest.class.cast(target);
-        if(Objects.isNull(request.getPassword()))
+        if(Objects.isNull(request.getPassword())|| request.getPassword().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_PASSWORD);
 
     }

--- a/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberRemoveRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberRemoveRequestValidator.java
@@ -31,9 +31,9 @@ public class MemberRemoveRequestValidator implements Validator {
             return;
         }
         MemberRemoveRequest request = MemberRemoveRequest.class.cast(target);
-        if(Objects.isNull(request.getUserId()))
-            throw new BizException(MemberExceptionType.NOT_FOUND_LOGIN_ID);
-        if(Objects.isNull(request.getPassword()))
+        if(Objects.isNull(request.getUserId())|| request.getUserId().length() == 0)
+            throw new BizException(MemberExceptionType.NOT_FOUND_USER_ID);
+        if(Objects.isNull(request.getPassword())|| request.getPassword().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_PASSWORD);
     }
 }

--- a/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberSaveRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberSaveRequestValidator.java
@@ -31,11 +31,11 @@ public class MemberSaveRequestValidator implements Validator {
             return;
         }
         MemberSaveRequest request = MemberSaveRequest.class.cast(target);
-        if(Objects.isNull(request.getLoginId()))
+        if(Objects.isNull(request.getLoginId())|| request.getLoginId().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_LOGIN_ID);
-        if(Objects.isNull(request.getPassword()))
+        if(Objects.isNull(request.getPassword())|| request.getPassword().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_PASSWORD);
-        if(Objects.isNull(request.getUsername()))
+        if(Objects.isNull(request.getUsername())|| request.getUsername().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_USERNAME);
         // TODO 프로필 이미지가 필수인지 확인하고 활성화할지 비활할지 선택하기
 //        if(Objects.isNull(request.getProfileImage()))

--- a/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberSaveRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberSaveRequestValidator.java
@@ -37,10 +37,7 @@ public class MemberSaveRequestValidator implements Validator {
             throw new BizException(MemberExceptionType.NOT_FOUND_PASSWORD);
         if(Objects.isNull(request.getUsername())|| request.getUsername().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_USERNAME);
-        // TODO 프로필 이미지가 필수인지 확인하고 활성화할지 비활할지 선택하기
-//        if(Objects.isNull(request.getProfileImage()))
-//            throw new BizException(MemberExceptionType.NOT_FOUND_PROFILE_IMAGE);
-
-
+        if(Objects.isNull(request.getProfileImage()) || request.getProfileImage().length() == 0)
+            throw new BizException(MemberExceptionType.NOT_FOUND_PROFILE_IMAGE);
     }
 }

--- a/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberUpdatePasswordRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/validator/MemberUpdatePasswordRequestValidator.java
@@ -31,7 +31,7 @@ public class MemberUpdatePasswordRequestValidator implements Validator {
             return;
         }
         MemberUpdatePasswordRequest request = MemberUpdatePasswordRequest.class.cast(target);
-        if(Objects.isNull(request.getNewPassword()))
+        if(Objects.isNull(request.getNewPassword())|| request.getNewPassword().length() == 0)
             throw new BizException(MemberExceptionType.NOT_FOUND_NEW_PASSWORD);
 
     }

--- a/src/main/java/com/sweep/jaksim31/dto/token/validator/TokenRequestValidator.java
+++ b/src/main/java/com/sweep/jaksim31/dto/token/validator/TokenRequestValidator.java
@@ -34,6 +34,12 @@ public class TokenRequestValidator implements Validator {
         // 입력 된 토큰이 아무것도 없을 경우
         if(Objects.isNull(request.getAccessToken()) && Objects.isNull(request.getRefreshToken()))
             throw new BizException(JwtExceptionType.EMPTY_TOKEN);
+        else if(request.getAccessToken().length() == 0 && Objects.isNull(request.getRefreshToken()))
+            throw new BizException(JwtExceptionType.EMPTY_TOKEN);
+        else if(request.getAccessToken().length() == 0  && request.getRefreshToken().length() == 0)
+            throw new BizException(JwtExceptionType.EMPTY_TOKEN);
+        else if(Objects.isNull(request.getAccessToken()) && request.getRefreshToken().length() == 0)
+            throw new BizException(JwtExceptionType.EMPTY_TOKEN);
 
     }
 }

--- a/src/main/java/com/sweep/jaksim31/exception/type/MemberExceptionType.java
+++ b/src/main/java/com/sweep/jaksim31/exception/type/MemberExceptionType.java
@@ -24,6 +24,7 @@ public enum MemberExceptionType implements BaseExceptionType {
     NOT_FOUND_AUTHENTICATION("NOT_FOUND_AUTHENTICATION","인증 정보를 찾을 수 없습니다.", HttpStatus.BAD_REQUEST),
     DUPLICATE_USER("DUPLICATE_USER","이미 존재하는 사용자입니다.", HttpStatus.BAD_REQUEST),
     WRONG_PASSWORD("WRONG_PASSWORD","비밀번호를 잘못 입력하였습니다.", HttpStatus.UNAUTHORIZED),
+    NOT_FOUND_USER_ID("NOT_FOUND_USER_ID","사용자 아이디가 비어있습니다.",HttpStatus.BAD_REQUEST),
     NOT_FOUND_LOGIN_ID("NOT_FOUND_LOGIN_ID","로그인 아이디를 입력해주세요",HttpStatus.BAD_REQUEST),
     NOT_FOUND_PASSWORD("NOT_FOUND_PASSWORD","비밀번호를 입력해주세요",HttpStatus.BAD_REQUEST),
     NOT_FOUND_USERNAME("NOT_FOUND_USERNAME","사용자 이름을 입력해주세요",HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/sweep/jaksim31/exception/type/MemberExceptionType.java
+++ b/src/main/java/com/sweep/jaksim31/exception/type/MemberExceptionType.java
@@ -28,6 +28,7 @@ public enum MemberExceptionType implements BaseExceptionType {
     NOT_FOUND_LOGIN_ID("NOT_FOUND_LOGIN_ID","로그인 아이디를 입력해주세요",HttpStatus.BAD_REQUEST),
     NOT_FOUND_PASSWORD("NOT_FOUND_PASSWORD","비밀번호를 입력해주세요",HttpStatus.BAD_REQUEST),
     NOT_FOUND_USERNAME("NOT_FOUND_USERNAME","사용자 이름을 입력해주세요",HttpStatus.BAD_REQUEST),
+    NOT_FOUND_PROFILE_IMAGE("NOT_FOUND_PROFILE_IMAGE","프로필 이미지를 찾을 수 없습니다.",HttpStatus.BAD_REQUEST),
     NOT_FOUND_NEW_PASSWORD("NOT_FOUND_NEW_PASSWORD","새로운 비밀번호를 입력해주세요",HttpStatus.BAD_REQUEST),
     LOGOUT_MEMBER("LOGOUT_MEMBER","로그아웃된 사용자입니다.",HttpStatus.BAD_REQUEST),
 

--- a/src/main/java/com/sweep/jaksim31/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/DiaryServiceImpl.java
@@ -294,7 +294,7 @@ public class DiaryServiceImpl implements DiaryService {
                 .findById(userId)
                 .orElseThrow(() -> new BizException(MemberExceptionType.NOT_FOUND_USER));
         Pageable pageable;
-        // paging 설정 값이 비어있다면, 기본값(첫번째 페이지(0), size=9) 세팅
+        // paging 설정 값이 비어있다면, 기본값(첫번째 페이지(0), size=사용자 total 일기 수) 세팅
         if(!params.containsKey("page"))
             params.put("page", "0");
         if(!params.containsKey("size"))

--- a/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerNullTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerNullTest.java
@@ -1,0 +1,403 @@
+package com.sweep.jaksim31.controller;
+
+import com.sweep.jaksim31.adapter.RestPage;
+import com.sweep.jaksim31.controller.feign.*;
+import com.sweep.jaksim31.domain.auth.AuthorityRepository;
+import com.sweep.jaksim31.domain.diary.Diary;
+import com.sweep.jaksim31.domain.diary.DiaryRepository;
+import com.sweep.jaksim31.domain.members.MemberRepository;
+import com.sweep.jaksim31.domain.token.RefreshTokenRepository;
+import com.sweep.jaksim31.dto.diary.*;
+import com.sweep.jaksim31.exception.BizException;
+import com.sweep.jaksim31.exception.type.DiaryExceptionType;
+import com.sweep.jaksim31.exception.type.MemberExceptionType;
+import com.sweep.jaksim31.exception.type.ThirdPartyExceptionType;
+import com.sweep.jaksim31.service.impl.DiaryServiceImpl;
+import com.sweep.jaksim31.utils.JsonUtil;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * packageName :  com.sweep.jaksim31.controller
+ * fileName : DiaryApiControllerNullTest
+ * author :  김주현
+ * date : 2023-01-27
+ * description : DiaryApiController Validator test(NULL exception 확인)
+ * ===========================================================
+ * DATE                 AUTHOR                NOTE
+ * -----------------------------------------------------------
+ * 2023-01-27              김주현             최초 생성
+ */
+
+@WebMvcTest(controllers = DiaryApiController.class)
+@ExtendWith(MockitoExtension.class)
+@WithMockUser // 401 에러 방지
+public class DiaryApiControllerNullTest  {
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private DiaryServiceImpl diaryService;
+    @MockBean
+    private DiaryRepository diaryRepository;
+    @MockBean
+    private MemberRepository memberRepository;
+    @MockBean
+    private UploadImageFeign uploadImageFeign;
+    @MockBean
+    private DownloadImageFeign downloadImageFeign;
+    @MockBean
+    private KakaoApiTokenRefreshFeign apiTokenRefreshFeign;
+    @MockBean
+    private ExtractKeywordFeign extractKeywordFeign;
+    @MockBean
+    private TranslationFeign translationFeign;
+    @MockBean
+    private EmotionAnalysisFeign emotionAnalysisFeign;
+    @MockBean
+    private AuthorityRepository authorityRepository;
+    @MockBean
+    private RefreshTokenRepository refreshTokenRepository;
+
+    @Nested
+    @DisplayName("일기 등록 컨트롤러")
+    class enrollDiary {
+        String[] keywords = {"happy"};
+        LocalDate date = LocalDate.of(2023, 1, 18);
+        @Test
+        @DisplayName("[예외]사용자 ID가 입력되지 않았을 때")
+        public void failSaveDiaryUserIdIsNULL() throws Exception{
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest(null, "contents", date, "happy", keywords,"thumbnail");
+            //when
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(post("/v0/diaries")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.USER_ID_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.USER_ID_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]일기 내용이 입력되지 않았을 때")
+        public void failSaveDiaryContentIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", null, date, "happy", keywords,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(post("/v0/diaries")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.CONTENT_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.CONTENT_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]감정 분석 결과가 입력되지 않았을 때")
+        public void failSaveDiaryEmotionIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, null, keywords,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(post("/v0/diaries")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.EMOTION_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.EMOTION_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]키워드가 입력되지 않았을 때(NULL)")
+        public void failSaveDiaryKeywordIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", null,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(post("/v0/diaries")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.KEYWORDS_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.KEYWORDS_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]썸네일 주소가 입력되지 않았을 때")
+        public void failSaveDiaryThumbnailIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,null);
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(post("/v0/diaries")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.THUMBNAIL_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.THUMBNAIL_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]일기 날짜가 입력되지 않았을 때")
+        public void failSaveDiaryDateIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", null, "happy", keywords,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(post("/v0/diaries")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.DIARY_DATE_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.DIARY_DATE_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+    }
+
+    @Nested
+    @DisplayName("일기 수정 컨트롤러")
+    class updateDiary {
+        String[] keywords = {"happy"};
+        LocalDate date = LocalDate.of(2023, 1, 18);
+        @Test
+        @DisplayName("[예외]사용자 ID가 입력되지 않았을 때")
+        public void failUpdateDiaryUserIdIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest(null, "contents", date, "happy", keywords,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(put("/v0/diaries/diaryId")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.USER_ID_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.USER_ID_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]일기 내용이 입력되지 않았을 때")
+        public void failUpdateDiaryContentIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", null, date, "happy", keywords,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(put("/v0/diaries/diaryId")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.CONTENT_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.CONTENT_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]감정 분석 결과가 입력되지 않았을 때")
+        public void failUpdateDiaryEmotionIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, null, keywords,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(put("/v0/diaries/diaryId")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.EMOTION_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.EMOTION_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]키워드가 입력되지 않았을 때(NULL)")
+        public void failUpdateDiaryKeywordIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", null,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(put("/v0/diaries/diaryId")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.KEYWORDS_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.KEYWORDS_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]썸네일 주소가 입력되지 않았을 때")
+        public void failUpdateDiaryThumbnailIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,null);
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(put("/v0/diaries/diaryId")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.THUMBNAIL_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.THUMBNAIL_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]일기 날짜가 입력되지 않았을 때")
+        public void failUpdateDiaryDateIsNULL() throws Exception{
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", null, "happy", keywords,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            mockMvc.perform(put("/v0/diaries/diaryId")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.DIARY_DATE_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.DIARY_DATE_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+    }
+
+    @Nested
+    @DisplayName("일기 분석 컨트롤러")
+    class analyzeDiary {
+        @Test
+        @DisplayName("[예외]분석 할 문장들이 입력되지 않았을 때(NULL)")
+        public void failAnalyzeDiaryInputSentencesIsNull() throws Exception{
+            //when
+            DiaryAnalysisRequest diaryAnalysisRequest = new DiaryAnalysisRequest();
+            diaryAnalysisRequest.setSentences(null);
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryAnalysisRequest);
+
+            mockMvc.perform(post("/v0/diaries/analyze")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.INPUT_SENTENCES_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.INPUT_SENTENCES_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+    }
+
+    @Nested
+    @DisplayName("썸네일 생성 컨트롤러")
+    class saveThumbnail {
+        @Test
+        @DisplayName("[예외]사용자 ID가 입력되지 않았을 때")
+        public void failSaveThumbnailUserIdIsNULL() throws Exception{
+            //when
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest(null,"diaryId","thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
+
+            mockMvc.perform(put("/v0/diaries/thumbnail")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.USER_ID_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.USER_ID_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]일기 ID가 입력되지 않았을 때")
+        public void failSaveThumbnailDiaryIdIsNULL() throws Exception{
+            //when
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId",null,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
+
+            mockMvc.perform(put("/v0/diaries/thumbnail")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.DIARY_ID_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.DIARY_ID_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("[예외]썸네일 이미지 경로가 입력되지 않았을 때")
+        public void failSaveThumbnailURIIsNULL() throws Exception{
+            //when
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId","diaryId",null);
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
+
+            mockMvc.perform(put("/v0/diaries/thumbnail")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.THUMBNAIL_IS_NULL.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.THUMBNAIL_IS_NULL.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+    }
+}

--- a/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
@@ -181,12 +181,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]사용자 ID가 입력되지 않았을 때")
         public void failSaveDiaryUserIdIsNULL() throws Exception{
-            //given
-            given(diaryService.saveDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.USER_ID_IS_NULL));
-
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("", "contents", date, "happy", keywords,"thumbnail");
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest(null, "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/v0/diaries")
@@ -203,12 +199,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]일기 내용이 입력되지 않았을 때")
         public void failSaveDiaryContentIsNULL() throws Exception{
-            //given
-            given(diaryService.saveDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.CONTENT_IS_NULL));
-
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", null, date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/v0/diaries")
@@ -225,12 +217,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]감정 분석 결과가 입력되지 않았을 때")
         public void failSaveDiaryEmotionIsNULL() throws Exception{
-            //given
-            given(diaryService.saveDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.EMOTION_IS_NULL));
-
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, null, keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/v0/diaries")
@@ -245,35 +233,9 @@ public class DiaryApiControllerTest  {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
         @Test
-        @DisplayName("[예외]키워드가 입력되지 않았을 때(NULL)")
-        public void failSaveDiaryKeywordIsNULL() throws Exception{
-            //given
-            given(diaryService.saveDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.KEYWORDS_IS_NULL));
-
-            //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"thumbnail");
-            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
-
-            mockMvc.perform(post("/v0/diaries")
-                            .with(csrf()) //403 에러 방지
-                            .content(jsonRequest)
-                            .contentType(MediaType.APPLICATION_JSON))
-                    //then
-                    .andExpect(status().is4xxClientError())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.KEYWORDS_IS_NULL.getErrorCode())))
-                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.KEYWORDS_IS_NULL.getMessage())))
-                    .andDo(MockMvcResultHandlers.print(System.out));
-        }
-        @Test
         @DisplayName("[예외]키워드가 입력되지 않았을 때(Empty)")
         public void failSaveDiaryKeywordIsEmpty() throws Exception{
             String[] empty_keywords = new String[0];
-            //given
-            given(diaryService.saveDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.KEYWORDS_IS_NULL));
-
             //when
             DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", empty_keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
@@ -292,12 +254,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]썸네일 주소가 입력되지 않았을 때")
         public void failSaveDiaryThumbnailIsNULL() throws Exception{
-            //given
-            given(diaryService.saveDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.THUMBNAIL_IS_NULL));
-
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,null);
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/v0/diaries")
@@ -312,35 +270,9 @@ public class DiaryApiControllerTest  {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
         @Test
-        @DisplayName("[예외]일기 날짜가 입력되지 않았을 때")
-        public void failSaveDiaryDateIsNULL() throws Exception{
-            //given
-            given(diaryService.saveDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.DIARY_DATE_IS_NULL));
-
-            //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", null, "happy", keywords,"thumbnail");
-            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
-
-            mockMvc.perform(post("/v0/diaries")
-                            .with(csrf()) //403 에러 방지
-                            .content(jsonRequest)
-                            .contentType(MediaType.APPLICATION_JSON))
-                    //then
-                    .andExpect(status().is4xxClientError())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.DIARY_DATE_IS_NULL.getErrorCode())))
-                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.DIARY_DATE_IS_NULL.getMessage())))
-                    .andDo(MockMvcResultHandlers.print(System.out));
-        }
-        @Test
         @DisplayName("[예외]날짜가 유효하지 않을 때")
         public void failSaveDiaryWrongDate() throws Exception{
             date = LocalDate.now().plusDays(1);
-            //given
-            given(diaryService.saveDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.WRONG_DATE));
-
             //when
             DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
@@ -585,12 +517,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]사용자 ID가 입력되지 않았을 때")
         public void failUpdateDiaryUserIdIsNULL() throws Exception{
-            //given
-            given(diaryService.updateDiary(any(),any()))
-                    .willThrow(new BizException(DiaryExceptionType.USER_ID_IS_NULL));
-
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest(null, "contents", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(put("/v0/diaries/diaryId")
@@ -607,12 +535,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]일기 내용이 입력되지 않았을 때")
         public void failUpdateDiaryContentIsNULL() throws Exception{
-            //given
-            given(diaryService.updateDiary(any(),any()))
-                    .willThrow(new BizException(DiaryExceptionType.CONTENT_IS_NULL));
-
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", null, date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(put("/v0/diaries/diaryId")
@@ -629,12 +553,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]감정 분석 결과가 입력되지 않았을 때")
         public void failUpdateDiaryEmotionIsNULL() throws Exception{
-            //given
-            given(diaryService.updateDiary(any(),any()))
-                    .willThrow(new BizException(DiaryExceptionType.EMOTION_IS_NULL));
-
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, null, keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(put("/v0/diaries/diaryId")
@@ -649,35 +569,9 @@ public class DiaryApiControllerTest  {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
         @Test
-        @DisplayName("[예외]키워드가 입력되지 않았을 때(NULL)")
-        public void failUpdateDiaryKeywordIsNULL() throws Exception{
-            //given
-            given(diaryService.updateDiary(any(),any()))
-                    .willThrow(new BizException(DiaryExceptionType.KEYWORDS_IS_NULL));
-
-            //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"thumbnail");
-            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
-
-            mockMvc.perform(put("/v0/diaries/diaryId")
-                            .with(csrf()) //403 에러 방지
-                            .content(jsonRequest)
-                            .contentType(MediaType.APPLICATION_JSON))
-                    //then
-                    .andExpect(status().is4xxClientError())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.KEYWORDS_IS_NULL.getErrorCode())))
-                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.KEYWORDS_IS_NULL.getMessage())))
-                    .andDo(MockMvcResultHandlers.print(System.out));
-        }
-        @Test
         @DisplayName("[예외]키워드가 입력되지 않았을 때(Empty)")
         public void failUpdateDiaryKeywordIsEmpty() throws Exception{
             String[] empty_keywords = new String[0];
-            //given
-            given(diaryService.updateDiary(any(),any()))
-                    .willThrow(new BizException(DiaryExceptionType.KEYWORDS_IS_NULL));
-
             //when
             DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", empty_keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
@@ -696,12 +590,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]썸네일 주소가 입력되지 않았을 때")
         public void failUpdateDiaryThumbnailIsNULL() throws Exception{
-            //given
-            given(diaryService.updateDiary(any(),any()))
-                    .willThrow(new BizException(DiaryExceptionType.THUMBNAIL_IS_NULL));
-
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,null);
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(put("/v0/diaries/diaryId")
@@ -716,35 +606,9 @@ public class DiaryApiControllerTest  {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
         @Test
-        @DisplayName("[예외]일기 날짜가 입력되지 않았을 때")
-        public void failUpdateDiaryDateIsNULL() throws Exception{
-            //given
-            given(diaryService.updateDiary(any(),any()))
-                    .willThrow(new BizException(DiaryExceptionType.DIARY_DATE_IS_NULL));
-
-            //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", null, "happy", keywords,"thumbnail");
-            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
-
-            mockMvc.perform(put("/v0/diaries/diaryId")
-                            .with(csrf()) //403 에러 방지
-                            .content(jsonRequest)
-                            .contentType(MediaType.APPLICATION_JSON))
-                    //then
-                    .andExpect(status().is4xxClientError())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.DIARY_DATE_IS_NULL.getErrorCode())))
-                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.DIARY_DATE_IS_NULL.getMessage())))
-                    .andDo(MockMvcResultHandlers.print(System.out));
-        }
-        @Test
         @DisplayName("[예외]날짜가 유효하지 않을 때")
         public void failUpdateDiaryWrongDate() throws Exception{
             date = LocalDate.now().plusDays(1);
-            //given
-            given(diaryService.updateDiary(any(),any()))
-                    .willThrow(new BizException(DiaryExceptionType.WRONG_DATE));
-
             //when
             DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
@@ -839,36 +703,9 @@ public class DiaryApiControllerTest  {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
         @Test
-        @DisplayName("[예외]분석 할 문장들이 입력되지 않았을 때(NULL)")
-        public void failAnalyzeDiaryInputSentencesIsNull() throws Exception{
-            //given
-            given(diaryService.analyzeDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.INPUT_SENTENCES_IS_NULL));
-
-            //when
-            DiaryAnalysisRequest diaryAnalysisRequest = new DiaryAnalysisRequest();
-            diaryAnalysisRequest.setSentences(null);
-            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryAnalysisRequest);
-
-            mockMvc.perform(post("/v0/diaries/analyze")
-                            .with(csrf()) //403 에러 방지
-                            .content(jsonRequest)
-                            .contentType(MediaType.APPLICATION_JSON))
-                    //then
-                    .andExpect(status().is4xxClientError())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.INPUT_SENTENCES_IS_NULL.getErrorCode())))
-                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.INPUT_SENTENCES_IS_NULL.getMessage())))
-                    .andDo(MockMvcResultHandlers.print(System.out));
-        }
-        @Test
         @DisplayName("[예외]분석 할 문장들이 입력되지 않았을 때(Empty)")
         public void failAnalyzeDiaryInputSentencesIsEmpty() throws Exception{
             List<String> empty_sentences = List.of(new String[0]);
-            //given
-            given(diaryService.analyzeDiary(any()))
-                    .willThrow(new BizException(DiaryExceptionType.INPUT_SENTENCES_IS_NULL));
-
             //when
             DiaryAnalysisRequest diaryAnalysisRequest = new DiaryAnalysisRequest();
             diaryAnalysisRequest.setSentences(empty_sentences);
@@ -1007,12 +844,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]사용자 ID가 입력되지 않았을 때")
         public void failSaveThumbnailUserIdIsNULL() throws Exception{
-            //given
-            given(diaryService.saveThumbnail(any()))
-                    .willThrow(new BizException(DiaryExceptionType.USER_ID_IS_NULL));
-
             //when
-            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest(null,"diaryId","thumbnail");
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("","diaryId","thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
 
             mockMvc.perform(put("/v0/diaries/thumbnail")
@@ -1029,12 +862,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]일기 ID가 입력되지 않았을 때")
         public void failSaveThumbnailDiaryIdIsNULL() throws Exception{
-            //given
-            given(diaryService.saveThumbnail(any()))
-                    .willThrow(new BizException(DiaryExceptionType.DIARY_ID_IS_NULL));
-
             //when
-            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId",null,"thumbnail");
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId","","thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
 
             mockMvc.perform(put("/v0/diaries/thumbnail")
@@ -1051,12 +880,8 @@ public class DiaryApiControllerTest  {
         @Test
         @DisplayName("[예외]썸네일 이미지 경로가 입력되지 않았을 때")
         public void failSaveThumbnailURIIsNULL() throws Exception{
-            //given
-            given(diaryService.saveThumbnail(any()))
-                    .willThrow(new BizException(DiaryExceptionType.THUMBNAIL_IS_NULL));
-
             //when
-            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId","diaryId",null);
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId","diaryId","");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
 
             mockMvc.perform(put("/v0/diaries/thumbnail")

--- a/src/test/java/com/sweep/jaksim31/controller/MemberApiControllerNullTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/MemberApiControllerNullTest.java
@@ -1,0 +1,359 @@
+package com.sweep.jaksim31.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sweep.jaksim31.domain.auth.AuthorityRepository;
+import com.sweep.jaksim31.domain.diary.Diary;
+import com.sweep.jaksim31.domain.diary.DiaryRepository;
+import com.sweep.jaksim31.domain.members.MemberRepository;
+import com.sweep.jaksim31.domain.token.RefreshTokenRepository;
+import com.sweep.jaksim31.dto.login.KakaoLoginRequest;
+import com.sweep.jaksim31.dto.login.KakaoProfile;
+import com.sweep.jaksim31.dto.login.LoginRequest;
+import com.sweep.jaksim31.dto.member.*;
+import com.sweep.jaksim31.dto.token.TokenRequest;
+import com.sweep.jaksim31.dto.token.TokenResponse;
+import com.sweep.jaksim31.exception.BizException;
+import com.sweep.jaksim31.exception.type.JwtExceptionType;
+import com.sweep.jaksim31.exception.type.MemberExceptionType;
+import com.sweep.jaksim31.service.impl.KaKaoMemberServiceImpl;
+import com.sweep.jaksim31.service.impl.MemberServiceImpl;
+import com.sweep.jaksim31.utils.JsonUtil;
+import com.sweep.jaksim31.utils.RedirectionUtil;
+import io.swagger.v3.core.util.Json;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.platform.engine.support.discovery.SelectorResolver;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.event.annotation.BeforeTestMethod;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
+import org.springframework.util.MultiValueMap;
+
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+/**
+ * packageName :  com.sweep.jaksim31.controller
+ * fileName : MemberApiControllerNullTest
+ * author :  김주현
+ * date : 2023-01-27
+ * description : MemberApiController Validator test(NULL exception 확인)
+ * ===========================================================
+ * DATE                 AUTHOR                NOTE
+ * -----------------------------------------------------------
+ * 2023-01-27              김주현             최초 생성
+ */
+
+@WebMvcTest(controllers = MembersApiController.class)
+@ExtendWith(MockitoExtension.class)
+@WithMockUser // 401 에러 방지
+class MemberApiControllerNullTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @MockBean
+    private MemberServiceImpl memberService;
+
+    @MockBean
+    private KaKaoMemberServiceImpl kaKaoMemberService;
+
+    @MockBean
+    private MemberRepository memberRepository;
+
+    @MockBean
+    private AuthorityRepository authorityRepository;
+    @MockBean
+    private RefreshTokenRepository refreshTokenRepository;
+    @MockBean
+    private DiaryRepository diaryRepository;
+
+    @MockBean
+    private RedirectionUtil redirectionUtil;
+
+    MemberInfoResponse memberInfoResponse = MemberInfoResponse.builder()
+            .loginId("loginId")
+            .userId("userId")
+            .username("username")
+            .profileImage("profileImage")
+            .diaryTotal(10)
+            .build();
+
+    @Nested
+    @DisplayName("SignUp Controller")
+    class SignUp {
+        @Test
+        @DisplayName("사용자 아이디를 입력하지 않은 경우")
+        public void invalidSingupNotFoundLoginId() throws Exception {
+            //when
+            MemberSaveRequest memberSaveRequest = new MemberSaveRequest(null, "password", "geunho", "profileImage");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberSaveRequest);
+
+            mockMvc.perform(post("/v0/members/register")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
+        @Test
+        @DisplayName("비밀번호를 입력하지 않은 경우")
+        public void invalidSingupNotFoundPassword() throws Exception {
+            //when
+            MemberSaveRequest memberSaveRequest = new MemberSaveRequest("loginId", null, "geunho", "profileImage");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberSaveRequest);
+
+            mockMvc.perform(post("/v0/members/register")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
+        @Test
+        @DisplayName("사용자 이름울 입력하지 않은 경우")
+        public void invalidSingupNotFoundUsername() throws Exception {
+            //when
+            MemberSaveRequest memberSaveRequest = new MemberSaveRequest("loginId", "password", null, "profileImage");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberSaveRequest);
+
+            mockMvc.perform(post("/v0/members/register")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_USERNAME.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_USERNAME.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
+
+    }
+
+    @Nested
+    @DisplayName("Login Controller")
+    class login {
+        @Test
+        @DisplayName("로그인 ID를 입력하지 않은 경우")
+        void invalidLoginNotFoundLoginId() throws Exception {
+            // when
+            LoginRequest loginRequest = new LoginRequest(null, "password");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(loginRequest);
+
+            mockMvc.perform(post("/v0/members/login")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("비밀번호를 입력하지 않은 경우")
+        void invalidLoginNotFoundPassword() throws Exception {
+            // when
+            LoginRequest loginRequest = new LoginRequest("loginId", null);
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(loginRequest);
+
+            mockMvc.perform(post("/v0/members/login")
+                            .with(csrf()) //403 에러 방지
+                            .param("redirectUri", "http://adsaadsadadadad")
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Reissue Controller")
+    class Reissue {
+        @Test
+        @DisplayName("토큰 값이 비어있는 경우")
+        void invalidReissueEmptyToken() throws Exception {
+            //when
+            TokenRequest tokenRequest = new TokenRequest(null, null);
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(tokenRequest);
+
+            mockMvc.perform(post("/v0/members/geunho/reissue")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(JwtExceptionType.EMPTY_TOKEN.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(JwtExceptionType.EMPTY_TOKEN.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+
+        }
+
+    }
+
+
+    @Nested
+    @DisplayName("isMember Controller")
+    class IsMember {
+        @Test
+        @DisplayName("로그인 아이디를 입력하지 않은 경우")
+        void invalidIsMemberNotFoundLoginId() throws Exception {
+            //when
+            MemberCheckLoginIdRequest memberCheckLoginIdRequest = new MemberCheckLoginIdRequest(null);
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberCheckLoginIdRequest);
+
+            mockMvc.perform(post("/v0/members")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("Change Password Controller")
+    class ChangePassword {
+        @DisplayName("새로운 비밀번호가 입력되지 않은 경우")
+        @Test
+        void invalidChangePwNotFoundNewPassword() throws Exception {
+            //when
+            MemberUpdatePasswordRequest memberUpdatePasswordRequest = new MemberUpdatePasswordRequest(null);
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberUpdatePasswordRequest);
+
+            mockMvc.perform(put("/v0/members/string/password")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_NEW_PASSWORD.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_NEW_PASSWORD.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+
+        }
+    }
+
+    // TODO Validator 확정 되면 테스트코드 추가
+//    @DisplayName("UpdateMember Controller")
+//    @Nested
+//    class UpdateMember {
+//
+//    }
+
+    @DisplayName("Remove Controller")
+    @Nested
+    class RemoveMember {
+        @DisplayName("사용자 아이디가 입력되지 않은 경우")
+        @Test
+        void invalidRemoveMemberNotFoundUserId() throws Exception {
+            //when
+            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest(null, "geunho");
+            String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
+
+            mockMvc.perform(delete("/v0/members/geunho")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonString))
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_USER_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_USER_ID.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @DisplayName("비밀번호가 입력되지 않은 경우")
+        @Test
+        void invalidRemoveMemberNotFoundPassword() throws Exception {
+            //when
+            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("geunho", null);
+            String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
+
+            mockMvc.perform(delete("/v0/members/geunho")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonString))
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("isMyPw Controller")
+    class IsMyPw {
+        @DisplayName("비밀번호를 입력하지 않은 경우")
+        @Test
+        void invalidPasswordIsMyPasswordNotFoundPassword() throws Exception {
+            MemberCheckPasswordRequest memberRemoveRequest = new MemberCheckPasswordRequest(null);
+            String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
+
+            mockMvc.perform(post("/v0/members/geunho/password")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonString))
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+    }
+}

--- a/src/test/java/com/sweep/jaksim31/controller/MemberApiControllerNullTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/MemberApiControllerNullTest.java
@@ -166,7 +166,25 @@ class MemberApiControllerNullTest {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
 
+        @Test
+        @DisplayName("프로필 이미지가 없는 경우")
+        public void invalidSingupNotFoundProfileImage() throws Exception {
+            //when
+            MemberSaveRequest memberSaveRequest = new MemberSaveRequest("loginId", "password", "username", null);
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberSaveRequest);
 
+            mockMvc.perform(post("/v0/members/register")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PROFILE_IMAGE.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PROFILE_IMAGE.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
     }
 
     @Nested

--- a/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
@@ -103,12 +103,9 @@ class MembersApiControllerTest {
             .diaryTotal(10)
             .build();
 
-
-
-
     @Nested
     @DisplayName("SignUp Controller")
-    class SingnUp {
+    class SignUp {
         @Test
         @DisplayName("정상인 경우")
         public void singup() throws Exception {
@@ -137,6 +134,68 @@ class MembersApiControllerTest {
                     .andExpect(jsonPath("$.username", Matchers.is("geunho")))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
+
+        @Test
+        @DisplayName("사용자 아이디를 입력하지 않은 경우")
+        public void invalidSingupNotFoundLoginId() throws Exception {
+            //when
+            MemberSaveRequest memberSaveRequest = new MemberSaveRequest("", "password", "geunho", "profileImage");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberSaveRequest);
+
+            mockMvc.perform(post("/v0/members/register")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
+        @Test
+        @DisplayName("비밀번호를 입력하지 않은 경우")
+        public void invalidSingupNotFoundPassword() throws Exception {
+            //when
+            MemberSaveRequest memberSaveRequest = new MemberSaveRequest("loginId", "", "geunho", "profileImage");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberSaveRequest);
+
+            mockMvc.perform(post("/v0/members/register")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
+        @Test
+        @DisplayName("사용자 이름울 입력하지 않은 경우")
+        public void invalidSingupNotFoundUsername() throws Exception {
+            //when
+            MemberSaveRequest memberSaveRequest = new MemberSaveRequest("loginId", "password", "", "profileImage");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberSaveRequest);
+
+            mockMvc.perform(post("/v0/members/register")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_USERNAME.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_USERNAME.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
+
     }
 
     @Nested
@@ -200,6 +259,44 @@ class MembersApiControllerTest {
                     .andExpect(jsonPath("$.errorMessage", Matchers.is("비밀번호를 잘못 입력하였습니다.")))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
+
+        @Test
+        @DisplayName("로그인 ID를 입력하지 않은 경우")
+        void invalidLoginNotFoundLoginId() throws Exception {
+            // when
+            LoginRequest loginRequest = new LoginRequest("", "password");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(loginRequest);
+
+            mockMvc.perform(post("/v0/members/login")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @Test
+        @DisplayName("비밀번호를 입력하지 않은 경우")
+        void invalidLoginNotFoundPassword() throws Exception {
+            // when
+            LoginRequest loginRequest = new LoginRequest("loginId", "");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(loginRequest);
+
+            mockMvc.perform(post("/v0/members/login")
+                            .with(csrf()) //403 에러 방지
+                            .param("redirectUri", "http://adsaadsadadadad")
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
     }
 
 
@@ -234,6 +331,58 @@ class MembersApiControllerTest {
                     .andExpect(jsonPath("$.accessToken", Matchers.is("accessToken")))
                     .andExpect(jsonPath("$.refreshToken", Matchers.is("refreshToken")))
                     .andExpect(jsonPath("$.expTime", Matchers.is("2000")))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+
+        }
+        @Test
+        @DisplayName("정상인 경우(refresh token만 있는 경우)")
+        void reissueRefreshTokenOnly() throws Exception {
+            //given
+            given(memberService.reissue(any(), any()))
+                    .willReturn(TokenResponse.builder()
+                            .memberInfoResponse(memberInfoResponse)
+                            .grantType("USER_ROLE")
+                            .accessToken("accessToken")
+                            .refreshToken("refreshToken")
+                            .expTime("2000")
+                            .build());
+
+            //when
+            TokenRequest tokenRequest = new TokenRequest("", "refreshToken");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(tokenRequest);
+
+            mockMvc.perform(post("/v0/members/geunho/reissue")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.grantType", Matchers.is("USER_ROLE")))
+                    .andExpect(jsonPath("$.memberInfo.loginId", Matchers.is("loginId")))
+                    .andExpect(jsonPath("$.accessToken", Matchers.is("accessToken")))
+                    .andExpect(jsonPath("$.refreshToken", Matchers.is("refreshToken")))
+                    .andExpect(jsonPath("$.expTime", Matchers.is("2000")))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+
+        }
+
+        @Test
+        @DisplayName("토큰 값이 비어있는 경우")
+        void invalidReissueEmptyToken() throws Exception {
+            //when
+            TokenRequest tokenRequest = new TokenRequest("", "");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(tokenRequest);
+
+            mockMvc.perform(post("/v0/members/geunho/reissue")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(JwtExceptionType.EMPTY_TOKEN.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(JwtExceptionType.EMPTY_TOKEN.getMessage())))
                     .andDo(MockMvcResultHandlers.print(System.out));
 
         }
@@ -286,6 +435,25 @@ class MembersApiControllerTest {
                     .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_USER.getMessage())))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
+
+        @Test
+        @DisplayName("로그인 아이디를 입력하지 않은 경우")
+        void invalidIsMemberNotFoundLoginId() throws Exception {
+            //when
+            MemberCheckLoginIdRequest memberCheckLoginIdRequest = new MemberCheckLoginIdRequest("");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberCheckLoginIdRequest);
+
+            mockMvc.perform(post("/v0/members")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_LOGIN_ID.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
     }
 
 
@@ -335,6 +503,26 @@ class MembersApiControllerTest {
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_USER.getErrorCode())))
                     .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_USER.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+
+        }
+
+        @DisplayName("새로운 비밀번호가 입력되지 않은 경우")
+        @Test
+        void invalidChangePwNotFoundNewPassword() throws Exception {
+            //when
+            MemberUpdatePasswordRequest memberUpdatePasswordRequest = new MemberUpdatePasswordRequest("");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberUpdatePasswordRequest);
+
+            mockMvc.perform(put("/v0/members/string/password")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_NEW_PASSWORD.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_NEW_PASSWORD.getMessage())))
                     .andDo(MockMvcResultHandlers.print(System.out));
 
         }
@@ -391,6 +579,7 @@ class MembersApiControllerTest {
         }
     }
 
+    // TODO Validator 확정 되면 테스트코드 추가
     @DisplayName("UpdateMember Controller")
     @Nested
     class UpdateMember {
@@ -468,7 +657,6 @@ class MembersApiControllerTest {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
 
-
         @DisplayName("해당 유저 정보가 없는 경우")
         @Test
         void invalidRemove2xx() throws Exception {
@@ -492,7 +680,6 @@ class MembersApiControllerTest {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
 
-
         @DisplayName("비밀번호가 불일치할 경우")
         @Test
         void invalidRemove4xx() throws Exception {
@@ -512,6 +699,42 @@ class MembersApiControllerTest {
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.WRONG_PASSWORD.getMessage())))
                     .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.WRONG_PASSWORD.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @DisplayName("사용자 아이디가 입력되지 않은 경우")
+        @Test
+        void invalidRemoveMemberNotFoundUserId() throws Exception {
+            //when
+            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("", "geunho");
+            String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
+
+            mockMvc.perform(delete("/v0/members/geunho")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonString))
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_USER_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_USER_ID.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @DisplayName("비밀번호가 입력되지 않은 경우")
+        @Test
+        void invalidRemoveMemberNotFoundPassword() throws Exception {
+            //when
+            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("geunho", "");
+            String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
+
+            mockMvc.perform(delete("/v0/members/geunho")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonString))
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getErrorCode())))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
     }
@@ -541,6 +764,23 @@ class MembersApiControllerTest {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
 
+        @DisplayName("비밀번호를 입력하지 않은 경우")
+        @Test
+        void invalidPasswordIsMyPasswordNotFoundPassword() throws Exception {
+            MemberCheckPasswordRequest memberRemoveRequest = new MemberCheckPasswordRequest("");
+            String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
+
+            mockMvc.perform(post("/v0/members/geunho/password")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonString))
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PASSWORD.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
 
         @DisplayName("해당 유저 정보가 없는 경우")
         @Test
@@ -564,7 +804,6 @@ class MembersApiControllerTest {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
 
-
         @DisplayName("비밀번호가 불일치할 경우")
         @Test
         void invalidPasswordIsMyPassword() throws Exception {
@@ -586,6 +825,7 @@ class MembersApiControllerTest {
                     .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.WRONG_PASSWORD.getErrorCode())))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
+
     }
 
     @Nested

--- a/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
@@ -195,7 +195,25 @@ class MembersApiControllerTest {
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
 
+        @Test
+        @DisplayName("프로필 이미지가 없는 경우")
+        public void invalidSingupNotFoundProfileImage() throws Exception {
+            //when
+            MemberSaveRequest memberSaveRequest = new MemberSaveRequest("loginId", "password", "username", "");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(memberSaveRequest);
 
+            mockMvc.perform(post("/v0/members/register")
+                            .with(csrf()) //403 에러 방지
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON))
+
+                    //then
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.NOT_FOUND_PROFILE_IMAGE.getErrorCode())))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.NOT_FOUND_PROFILE_IMAGE.getMessage())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
     }
 
     @Nested


### PR DESCRIPTION
- Diary Validator 테스트 코드 추가
  > - DiarySaveRequestValidator : 일기 작성, 일기 수정
  > - DiaryAnalysisRequestValidator : 일기 분석
  > - DiaryThumbnailRequestValidator : 썸네일 저장

- `DiaryServiceImpl` 주석 수정(297p)

- Member Validator 테스트 코드 추가
  > - LoginRequestValidator(자체 로그인), MemberCheckLoginIdRequestValidator(가입확인), MemberCheckPasswordRequestValidator(비밀번호 확인), MemberRemoveRequestValidator(회원탈퇴), MemberSaveRequestValidator(회원가입), MemberUpdatePasswordRequestValidator(비밀번호 변경), TokenRequestValidator(토큰 요청(reissue))

- 모든 validator Exception 조건 추가
  > - input value type이 `String`인 경우 빈 스트링(`""`)으로 올 경우에도 예외처리
  > - 이로 인한 test code 추가

- MembersApiControllerTest, DiaryApiControllerTest -> 빈 스트링값(`""`)으로 들어오는 예외 test
  `(New)` MemberApiControllerNullTest, DiaryApiControllerNullTest -> Null 값으로 들어오는 예외 test

- `MemberExceptionType` : `NOT_FOUND_USER_ID` 추가
  > 사용자 id를 전달받지 못했을 때 throw 할 Exception type(회원 탈퇴 Validation 시 사용)

- `MemberSaveRequestValidator` 테스트 코드 추가
  > - 회원가입 시 프로필 이미지 없는 경우 throw `NOT_FOUND_PROFILE_IMAGE`(Validator 수정)
  > - 테스트 코드 추가
  > - Exception type(`NOT_FOUND_PROFILE_IMAGE`) 추가

- Member의 `updateMember` 수정
  > - 사용자 정보 업데이트 시 변경 값이 `""`일 경우에도 update 하지 않도록 조건 추가

![image](https://user-images.githubusercontent.com/64013256/215082731-a3c3ed9f-d4bd-4f98-a6c0-07734abe7098.png)
