### PR TITLE
[SW-119] CI/CD Process With Github Action

### DIFF
--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -1,0 +1,35 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
+    - name: Update dependency graph
+      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -18,7 +18,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-      
+
+    env:
+      DOCKER_ID: ${{ secrets.DOCKER_ID }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
@@ -45,6 +49,6 @@ jobs:
       uses: docker/login-action@v2.1.0
       with:
         # Username used to log against the Docker registry
-        username: ${{ secrets.DOCKER_ID }}
+        username: $DOCKER_ID
         # Password or personal access token used to log against the Docker registry
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        password: $DOCKER_PASSWORD

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -72,5 +72,6 @@ jobs:
           key: ${{ secrets.REMOTE_SSH_KEY }}
           # port: ${{ secrets.REMOTE_SSH_PORT }}
           script: |
+            sudo su
             docker pull r2god7k/jaksim31-backend:latest
     

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -15,10 +15,8 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
-
+  CI:
     runs-on: ubuntu-latest
-    
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
@@ -49,9 +47,9 @@ jobs:
       uses: docker/login-action@v2.1.0
       with:
         # Username used to log against the Docker registry
-        username: r2god7k
+        username: ${{ secrets.DOCKER_ID }}
         # Password or personal access token used to log against the Docker registry
-        password: 24382438ii!!
+        password: ${{ secrets.DOCKER_PASSWORD }}
         
     # Docker Build & Push    
     - name: Docker Build and push

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -15,14 +15,14 @@ on:
     branches: [ "main" ]
 
 jobs:
-  CI:
+  Initial-Setting:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
       with:
-        java-version: 1.8
+        java-version: '11'
         distribution: 'temurin'
         cache: maven
 
@@ -33,11 +33,17 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-        
+  
+  Build:
+    runs-on: ubuntu-latest
+    steps:
     # Build 
     - name: Build with Maven
       run: mvn -B package -D skipTests=true --file pom.xml 
-    
+  
+  Docker-Setting:
+    runs-on: ubuntu-latest
+    steps:
     # Docker Buildx Setting
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -51,6 +57,9 @@ jobs:
         # Password or personal access token used to log against the Docker registry
         password: ${{ secrets.DOCKER_PASSWORD }}
         
+  DockerBuild-Push:
+    runs-on: ubuntu-latest
+    steps:
     # Docker Build & Push    
     - name: Docker Build and push
       uses: docker/build-push-action@v2
@@ -62,7 +71,10 @@ jobs:
           tags: r2god7k/jaksim31-backend:latest
           cache-from: type=gha    # gha=Github Action Cache
           cache-to: type=gha,mode=max
-    
+  
+  SSH-Connect:
+    runs-on: ubuntu-latest
+    steps:
     # SSH Connect
     - name: Deploy to VM
       uses: appleboy/ssh-action@master

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -28,7 +28,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml --exclude-task test
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -74,5 +74,6 @@ jobs:
           script: |
             ls -a
             sudo su
+            sudo chmod 666 /var/run/docker.sock
             docker pull r2god7k/jaksim31-backend:latest
     

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -18,11 +18,11 @@ jobs:
   CI:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 8
-      uses: actions/setup-java@v3
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
       with:
-        java-version: '8'
+        java-version: 1.8
         distribution: 'temurin'
         cache: maven
 

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -6,7 +6,7 @@
 # separate terms of service, privacy policy, and support
 # documentation.
 
-name: Java CI with Maven
+name: Jaksim31-Backend CI/CD
 
 on:
   push:
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Set up JDK 11
+    - name: Set up JDK 8
       uses: actions/setup-java@v3
       with:
-        java-version: '11'
+        java-version: '8'
         distribution: 'temurin'
         cache: maven
 

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -39,3 +39,12 @@ jobs:
     # Build 
     - name: Build with Maven
       run: mvn -B package -D skipTests=true --file pom.xml 
+      
+    # Docker Login
+    - name: Docker Login
+      uses: docker/login-action@v2.1.0
+      with:
+        # Username used to log against the Docker registry
+        username: ${{ secrets.DOCKER_ID }}
+        # Password or personal access token used to log against the Docker registry
+        password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -37,8 +37,10 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
         
     # Build 
-    - name: Build with Maven
-      run: mvn -B package -D skipTests=true --file pom.xml 
+    # - name: Build with Maven
+    #   run: mvn -B package -D skipTests=true --file pom.xml 
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1 # buildx 설정
       
     # Docker Login
     - name: Docker Login

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -37,10 +37,12 @@ jobs:
         restore-keys: ${{ runner.os }}-m2
         
     # Build 
-    # - name: Build with Maven
-    #   run: mvn -B package -D skipTests=true --file pom.xml 
+    - name: Build with Maven
+      run: mvn -B package -D skipTests=true --file pom.xml 
+    
+    # Docker Buildx Setting
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1 # buildx 설정
+      uses: docker/setup-buildx-action@v1
       
     # Docker Login
     - name: Docker Login

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -79,4 +79,5 @@ jobs:
             sudo /usr/sbin/usermod -aG docker `user`
             sudo chown root:docker /var/run/docker.sock
             docker pull r2god7k/jaksim31-backend:latest
-    
+            docker compose up -d
+            

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -29,7 +29,3 @@ jobs:
         cache: maven
     - name: Build with Maven
       run: mvn -B package -D skipTests=true --file pom.xml 
-
-    # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -27,5 +27,15 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
         cache: maven
+
+    # Maven Package Caching     
+    - name: Cache Maven packages
+      uses: actions/cache@v2
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+        
+    # Build 
     - name: Build with Maven
       run: mvn -B package -D skipTests=true --file pom.xml 

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -74,6 +74,9 @@ jobs:
           script: |
             ls -a
             sudo su
-            sudo chmod 666 /var/run/docker.sock
+            # sudo chmod 666 /var/run/docker.sock
+            sudo /usr/sbin/groupadd -f docker
+            sudo /usr/sbin/usermod -aG docker `user`
+            sudo chown root:docker /var/run/docker.sock
             docker pull r2god7k/jaksim31-backend:latest
     

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -64,7 +64,7 @@ jobs:
           cache-to: type=gha,mode=max
     
     # SSH Connect
-    - name: Deploy
+    - name: Deploy to VM
       uses: appleboy/ssh-action@master
       with:
           host: ${{ secrets.REMOTE_IP }}
@@ -79,5 +79,6 @@ jobs:
             sudo /usr/sbin/usermod -aG docker `user`
             sudo chown root:docker /var/run/docker.sock
             docker pull r2god7k/jaksim31-backend:latest
-            docker compose up -d
+            docker run -d -p 8085:8080 --name jaksim31-backend r2god7k/jaksim31-backend
+            docker image rm r2god7k/jaksim31-backend:latest
             

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -18,7 +18,11 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    
+    env:
+      DOCKER_ID: ${{ secrets.DOCKER_ID }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
@@ -45,6 +49,6 @@ jobs:
       uses: docker/login-action@v2.1.0
       with:
         # Username used to log against the Docker registry
-        username: ${{ secrets.DOCKER_ID }}
+        username: $DOCKER_ID
         # Password or personal access token used to log against the Docker registry
-        password: ${{ secrets.DOCKER_PASSWORD }}
+        password: $DOCKER_PASSWORD

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -48,3 +48,12 @@ jobs:
         username: r2god7k
         # Password or personal access token used to log against the Docker registry
         password: 24382438ii!!
+        
+    # Docker Build & Push    
+    - name: Docker Build and push
+      uses: docker/build-push-action@v2
+      with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64
+          push: true

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -1,30 +1,54 @@
-name: Build and Push Docker Image
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
 on:
   push:
-    branches:
-      - main
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
 jobs:
-  build-and-push-image:
+  build:
+
     runs-on: ubuntu-latest
+    
     env:
       DOCKER_ID: ${{ secrets.DOCKER_ID }}
       DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
+    - uses: actions/checkout@v3
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
       with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
+        java-version: '11'
+        distribution: 'temurin'
+        cache: maven
 
-    - name: Build and push
-      id: docker_build
-      uses: docker/build-push-action@v2
+    # Maven Package Caching     
+    - name: Cache Maven packages
+      uses: actions/cache@v2
       with:
-        push: true
-        tags: r2god7k/jaksim31:latest
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+        restore-keys: ${{ runner.os }}-m2
+        
+    # Build 
+    - name: Build with Maven
+      run: mvn -B package -D skipTests=true --file pom.xml 
+      
+    # Docker Login
+    - name: Docker Login
+      uses: docker/login-action@v2.1.0
+      with:
+        # Username used to log against the Docker registry
+        username: $DOCKER_ID
+        # Password or personal access token used to log against the Docker registry
+        password: $DOCKER_PASSWORD

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -18,10 +18,6 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    
-    env:
-      DOCKER_ID: ${{ secrets.DOCKER_ID }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
       
     steps:
     - uses: actions/checkout@v3
@@ -49,6 +45,6 @@ jobs:
       uses: docker/login-action@v2.1.0
       with:
         # Username used to log against the Docker registry
-        username: $DOCKER_ID
+        username: ${{ secrets.DOCKER_ID }}
         # Password or personal access token used to log against the Docker registry
-        password: $DOCKER_PASSWORD
+        password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -15,10 +15,12 @@ on:
     branches: [ "main" ]
 
 jobs:
-  Initial-Setting:
+  Backend-CICD:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+    
+    # JDK Setting
     - name: Set up JDK 11
       uses: actions/setup-java@v3
       with:
@@ -33,17 +35,11 @@ jobs:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ runner.os }}-m2
-  
-  Build:
-    runs-on: ubuntu-latest
-    steps:
+        
     # Build 
     - name: Build with Maven
       run: mvn -B package -D skipTests=true --file pom.xml 
-  
-  Docker-Setting:
-    runs-on: ubuntu-latest
-    steps:
+    
     # Docker Buildx Setting
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v1
@@ -57,9 +53,6 @@ jobs:
         # Password or personal access token used to log against the Docker registry
         password: ${{ secrets.DOCKER_PASSWORD }}
         
-  DockerBuild-Push:
-    runs-on: ubuntu-latest
-    steps:
     # Docker Build & Push    
     - name: Docker Build and push
       uses: docker/build-push-action@v2
@@ -71,10 +64,7 @@ jobs:
           tags: r2god7k/jaksim31-backend:latest
           cache-from: type=gha    # gha=Github Action Cache
           cache-to: type=gha,mode=max
-  
-  SSH-Connect:
-    runs-on: ubuntu-latest
-    steps:
+    
     # SSH Connect
     - name: Deploy to VM
       uses: appleboy/ssh-action@master

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -18,11 +18,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
-    env:
-      DOCKER_ID: ${{ secrets.DOCKER_ID }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
+    
     steps:
     - uses: actions/checkout@v3
     - name: Set up JDK 11
@@ -49,6 +45,6 @@ jobs:
       uses: docker/login-action@v2.1.0
       with:
         # Username used to log against the Docker registry
-        username: $DOCKER_ID
+        username: r2god7k
         # Password or personal access token used to log against the Docker registry
-        password: $DOCKER_PASSWORD
+        password: 24382438ii!!

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -62,3 +62,15 @@ jobs:
           tags: r2god7k/jaksim31-backend:latest
           cache-from: type=gha    # gha=Github Action Cache
           cache-to: type=gha,mode=max
+    
+    # SSH Connect
+    - name: Deploy
+      uses: appleboy/ssh-action@master
+      with:
+          host: ${{ secrets.REMOTE_IP }}
+          username: ${{ secrets.REMOTE_SSH_ID }}
+          key: ${{ secrets.REMOTE_SSH_KEY }}
+          # port: ${{ secrets.REMOTE_SSH_PORT }}
+          script: |
+            docker pull r2god7k/jaksim31-backend:latest
+    

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_ID: ${{ secrets.DOCKER_ID }}
+      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -1,54 +1,27 @@
-# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Java CI with Maven
-
+name: Build and Push Docker Image
 on:
   push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
-
+    branches:
+      - main
 jobs:
-  build:
-
+  build-and-push-image:
     runs-on: ubuntu-latest
-    
-    env:
-      DOCKER_ID: ${{ secrets.DOCKER_ID }}
-      DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-      
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-        cache: maven
+    - name: Checkout
+      uses: actions/checkout@v2
 
-    # Maven Package Caching     
-    - name: Cache Maven packages
-      uses: actions/cache@v2
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
       with:
-        path: ~/.m2
-        key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ runner.os }}-m2
-        
-    # Build 
-    - name: Build with Maven
-      run: mvn -B package -D skipTests=true --file pom.xml 
-      
-    # Docker Login
-    - name: Docker Login
-      uses: docker/login-action@v2.1.0
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+    - name: Build and push
+      id: docker_build
+      uses: docker/build-push-action@v2
       with:
-        # Username used to log against the Docker registry
-        username: $DOCKER_ID
-        # Password or personal access token used to log against the Docker registry
-        password: $DOCKER_PASSWORD
+        push: true
+        tags: r2god7k/jaksim31:latest

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -72,6 +72,7 @@ jobs:
           key: ${{ secrets.REMOTE_SSH_KEY }}
           # port: ${{ secrets.REMOTE_SSH_PORT }}
           script: |
+            ls -a
             sudo su
             docker pull r2god7k/jaksim31-backend:latest
     

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -62,3 +62,5 @@ jobs:
           platforms: linux/amd64
           push: true
           tags: r2god7k/jaksim31-backend:latest
+          cache-from: type=gha    # gha=Github Action Cache
+          cache-to: type=gha,mode=max

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -28,7 +28,7 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn -B package --file pom.xml --exclude-task test
+      run: mvn -B package -D skipTests=true --file pom.xml 
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph

--- a/.github/workflows/github-action.yml
+++ b/.github/workflows/github-action.yml
@@ -57,3 +57,4 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
+          tags: r2god7k/jaksim31-backend:latest


### PR DESCRIPTION
# Github Action CI/CD Process

## Complete
- JDK Setting
- Maven Package Caching ( Add for faster packaging. )
- Project Build ( Currently, exclude the Test process. )
- Docker Buildx Setting ( For Multi Platform building using Docker function. )
- Docker Login
- Docker build & push ( Using GithubActionCache(gha). To avoid redundant packaging of the layer. )
- SSH Connect & Deploy ( Now, connected with Bastion VM. Backend Project port uses 8085. ) 

## To Do
- Connect to Private IP using port forwarding of Nginx Proxy Manager.
- Change Tags when new image builds. ( Currently, all the tags are latest. )
- Environment Setting for "application.yml" file.
