### PR TITLE
SW-117 feat(diary): modify cookie settings sent upon login and MembersApiControllerTest error

### DIFF
--- a/src/main/java/com/sweep/jaksim31/service/impl/KaKaoMemberServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/KaKaoMemberServiceImpl.java
@@ -145,7 +145,7 @@ public class KaKaoMemberServiceImpl implements MemberService {
         long todayExpTime = LocalDateTime.of(today.plusDays(1), LocalTime.of(23, 59, 59,59)).toLocalTime().toSecondOfDay()
                 - LocalDateTime.now().toLocalTime().toSecondOfDay() + (3600*9); // GMT로 설정되어서 3600*9 추가..
 
-        CookieUtil.addSecureCookie(response, "todayDiaryId", Objects.nonNull(todayDiary) ? todayDiary.getId() : "", todayExpTime);
+        CookieUtil.addCookie(response, "todayDiaryId", Objects.nonNull(todayDiary) ? todayDiary.getId() : "", todayExpTime);
 
         return tokenProvider.createTokenDTO(accessToken,refreshToken, expTime);
 

--- a/src/main/java/com/sweep/jaksim31/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/MemberServiceImpl.java
@@ -149,7 +149,7 @@ public class MemberServiceImpl implements MemberService {
         long todayExpTime = LocalDateTime.of(today.plusDays(1), LocalTime.of(23, 59, 59,59)).toLocalTime().toSecondOfDay()
                 - LocalDateTime.now().toLocalTime().toSecondOfDay() + (3600*9); // GMT로 설정되어서 3600*9 추가..
 
-        CookieUtil.addSecureCookie(response, "todayDiaryId", Objects.nonNull(todayDiary) ? todayDiary.getId() : "", todayExpTime);
+        CookieUtil.addCookie(response, "todayDiaryId", Objects.nonNull(todayDiary) ? todayDiary.getId() : "", todayExpTime);
 
         return tokenProvider.createTokenDTO(accessToken,refreshToken, expTime);
 

--- a/src/main/java/com/sweep/jaksim31/utils/CookieUtil.java
+++ b/src/main/java/com/sweep/jaksim31/utils/CookieUtil.java
@@ -53,7 +53,7 @@ public class CookieUtil {
 
         ResponseCookie cookie = ResponseCookie.from(name, value)
                 .maxAge(maxAge)
-                .httpOnly(true)
+//                .httpOnly(true)
                 .secure(true)
                 .path("/")
                 .build();

--- a/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
@@ -353,7 +353,6 @@ class MembersApiControllerTest {
             //given
             given(memberService.reissue(any(), any()))
                     .willReturn(TokenResponse.builder()
-                            .memberInfoResponse(memberInfoResponse)
                             .grantType("USER_ROLE")
                             .accessToken("accessToken")
                             .refreshToken("refreshToken")
@@ -372,7 +371,6 @@ class MembersApiControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                     .andExpect(jsonPath("$.grantType", Matchers.is("USER_ROLE")))
-                    .andExpect(jsonPath("$.memberInfo.loginId", Matchers.is("loginId")))
                     .andExpect(jsonPath("$.accessToken", Matchers.is("accessToken")))
                     .andExpect(jsonPath("$.refreshToken", Matchers.is("refreshToken")))
                     .andExpect(jsonPath("$.expTime", Matchers.is("2000")))


### PR DESCRIPTION
### Modify cookie settings sent upon login and MembersApiControllerTest error

- 로그인 시 전달되는 쿠키 설정 변경
  > - CookieUtil 수정 : SecureCookie의 HttpOnly true => `false`로 변경(Frontend 에서 읽을 수 없음. 추후 다시 설정)
  > - todayDiaryId : SecureCookie => Secure 설정 없이 전달

- `MembersApiControllerTest` 수정
  > - `TokenResponse`의 `memberInfoResponse` 제거로 인한 test 코드 수정