### PR TITLE
SW-118 feat(diary): modify `findUserDiaries`, `findDiaries` service

### DIFF
--- a/src/main/java/com/sweep/jaksim31/service/impl/DiaryServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/DiaryServiceImpl.java
@@ -134,8 +134,12 @@ public class DiaryServiceImpl implements DiaryService {
         // paging 설정 값이 비어있다면, 기본값(첫번째 페이지(0), size=사용자 total 일기 수) 세팅
         if(!params.containsKey("page"))
             params.put("page", "0");
-        if(!params.containsKey("size"))
-            params.put("size", user.getDiaryTotal()+"");
+        if(!params.containsKey("size")) {
+            if (user.getDiaryTotal() > 0)
+                params.put("size", user.getDiaryTotal() + "");
+            else
+                params.put("size", "1");
+        }
         // sort가 없으면 최신순(default), asc라고 오면 오래된 순
         if(params.containsKey("sort") && params.get("sort").toString().equalsIgnoreCase("asc"))
             pageable = PageRequest.of(Integer.parseInt(params.get("page").toString()) , Integer.parseInt(params.get("size").toString()), Sort.by("date"));
@@ -297,8 +301,12 @@ public class DiaryServiceImpl implements DiaryService {
         // paging 설정 값이 비어있다면, 기본값(첫번째 페이지(0), size=사용자 total 일기 수) 세팅
         if(!params.containsKey("page"))
             params.put("page", "0");
-        if(!params.containsKey("size"))
-            params.put("size", user.getDiaryTotal()+"");
+        if(!params.containsKey("size")) {
+            if (user.getDiaryTotal() > 0)
+                params.put("size", user.getDiaryTotal() + "");
+            else
+                params.put("size", "1");
+        }
         // sort가 없으면 최신순(default), asc라고 오면 오래된 순
         if(params.containsKey("sort") && params.get("sort").toString().toLowerCase().equals("asc"))
             pageable = PageRequest.of(Integer.parseInt(params.get("page").toString()) , Integer.parseInt(params.get("size").toString()), Sort.by("date"));


### PR DESCRIPTION
- 사용자 일기 조회(전체/조건) 서비스 오류 수정
  > - api 요청 시 페이지 `size`에 대한 요청값이 없고, 사용자의 diaryTotal이 0인 경우(사용자가 등록한 다이어리가 없는 경우) 서버 오류가 발생하는 문제 => `Page size must not be less than one!`
  > -> `size` 입력값이 없고, 사용자의 `diaryTotal` 값이 0인 경우 size를 1로 설정