### PR TITLE
[ SW-116 / SW-117 ] Feature/validation

### DIFF
--- a/src/main/java/com/sweep/jaksim31/controller/DiaryApiController.java
+++ b/src/main/java/com/sweep/jaksim31/controller/DiaryApiController.java
@@ -5,6 +5,8 @@ import com.sweep.jaksim31.dto.diary.*;
 import com.sweep.jaksim31.dto.diary.validator.DiaryAnalysisRequestValidator;
 import com.sweep.jaksim31.dto.diary.validator.DiarySaveRequestValidator;
 import com.sweep.jaksim31.dto.diary.validator.DiaryThumbnailRequestValidator;
+import com.sweep.jaksim31.exception.handler.ErrorResponse;
+import com.sweep.jaksim31.exception.type.DiaryExceptionType;
 import com.sweep.jaksim31.service.impl.DiaryServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -15,9 +17,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.ConstraintViolationException;
+import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Map;
@@ -46,6 +52,7 @@ import java.util.Map;
  *                      김주현             일기 삭제 api path 및 input 값에 userId 추가
  * 2023-01-21           김주현             Validation 추가
  * 2023-01-26           김주현             사용자 일기 조회 조건에 searchWord(검색어) 추가
+ * 2023-02-01           김주현             PathValue(ObjectId_diaryId,userId) validation 추가
 */
 
 @Slf4j
@@ -53,8 +60,10 @@ import java.util.Map;
 @RequiredArgsConstructor
 @Tag(name = "일기", description = "일기 관련 api 입니다.")
 @RequestMapping(path = "/api/v1/diaries")
+@Validated
 public class DiaryApiController {
     private final DiaryServiceImpl diaryService;
+    private final String idPattern = "^[a-zA-Z0-9]{24}$";
     @InitBinder
     public void init(WebDataBinder binder) {
         binder.addValidators(new DiarySaveRequestValidator(), new DiaryThumbnailRequestValidator(), new DiaryAnalysisRequestValidator());
@@ -69,7 +78,6 @@ public class DiaryApiController {
     // 일기 등록
     @Operation(summary = "일기 등록", description = "일기를 저장합니다.")
     @PostMapping(value = "")
-    //BindingResult bindingResult 는 검증 되는 객체(@Validated로 선언 된 객체) 바로 뒤에 선언되어 있어야 한다.
     public ResponseEntity<DiaryResponse> saveDiary(@Validated @RequestBody DiarySaveRequest diarySaveRequest){
         return new ResponseEntity<>(diaryService.saveDiary(diarySaveRequest), HttpStatus.CREATED);
     }
@@ -77,7 +85,7 @@ public class DiaryApiController {
     // 일기 수정
     @Operation(summary = "일기 수정", description = "일기를 수정합니다.")
     @PutMapping(value = "{diaryId}")
-    public ResponseEntity<DiaryResponse> updateDiary(@PathVariable String diaryId,@Validated @RequestBody DiarySaveRequest diarySaveRequest){
+    public ResponseEntity<DiaryResponse> updateDiary(@Pattern(regexp = idPattern, message = "잘못 된 ID 값입니다.") @PathVariable String diaryId, @Valid @RequestBody DiarySaveRequest diarySaveRequest){
         System.out.printf("Diary ID \"%s\" Update%n",diaryId);
         return ResponseEntity.ok(diaryService.updateDiary(diaryId, diarySaveRequest));
     }
@@ -85,21 +93,21 @@ public class DiaryApiController {
     // 일기 삭제
     @Operation(summary = "일기 삭제", description = "일기를 삭제합니다.")
     @DeleteMapping(value="{userId}/{diaryId}")
-    public ResponseEntity<String> deleteDiary(@PathVariable String userId, @PathVariable String diaryId){
+    public ResponseEntity<String> deleteDiary(@Pattern(regexp = idPattern)@PathVariable String userId, @Pattern(regexp = idPattern)@PathVariable String diaryId){
         return ResponseEntity.ok(diaryService.remove(userId, diaryId));
     }
 
     // 개별 일기 조회
     @Operation(summary = "개별 일기 조회", description = "일기ID로 하나의 일기를 조회합니다.")
     @GetMapping(value="{userId}/{diaryId}")
-    public ResponseEntity<DiaryResponse> findDiary(@PathVariable String userId, @PathVariable String diaryId){
+    public ResponseEntity<DiaryResponse> findDiary(@Pattern(regexp = idPattern)@PathVariable String userId, @Pattern(regexp = idPattern) @PathVariable String diaryId){
         return ResponseEntity.ok(diaryService.findDiary(userId, diaryId));
     }
 
     // 사용자 일기 조회
     @Operation(summary = "사용자 일기 조회", description = "해당 사용자의 일기를 조회합니다. 조회 조건(Query parameter)이 없을 경우 해당 사용자의 전체 일기가 조회됩니다.")
     @GetMapping(value = "{userId}")
-    public ResponseEntity<Page<DiaryInfoResponse>> findUserDiary(@PathVariable String userId, @RequestParam(required = false) String page, @RequestParam(required = false) String size, @RequestParam(required = false) String sort, @RequestParam(required = false) Map<String, Object> params){
+    public ResponseEntity<Page<DiaryInfoResponse>> findUserDiary(@Pattern(regexp = idPattern)@PathVariable String userId, @RequestParam(required = false) String page, @RequestParam(required = false) String size, @RequestParam(required = false) String sort, @RequestParam(required = false) Map<String, Object> params){
         if(params.containsKey("emotion") || params.containsKey("startDate") || params.containsKey("endDate") || params.containsKey("searchWord")){
             // 페이징 및 정렬 외에 다른 조건이 있다면 ElasticSearch로 검색
             return ResponseEntity.ok(diaryService.findDiaries(userId, params));
@@ -123,9 +131,16 @@ public class DiaryApiController {
     
     @Operation(summary = "감정 통계", description = "사용자 일기에 대한 감정 통계를 제공합니다.")
     @GetMapping(value = "{userId}/emotions")
-    public ResponseEntity<DiaryEmotionStaticsResponse> emotionStatistics(@PathVariable String userId,  @RequestParam(required = false) String startDate, @RequestParam(required = false) String endDate, @RequestParam(required = false) Map<String, Object> params) {
+    public ResponseEntity<DiaryEmotionStaticsResponse> emotionStatistics(@Pattern(regexp = idPattern)@PathVariable String userId,  @RequestParam(required = false) String startDate, @RequestParam(required = false) String endDate, @RequestParam(required = false) Map<String, Object> params) {
         return ResponseEntity.ok(diaryService.emotionStatics(userId, params));
     }
 
-
+    //Validator Exception Handler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({ConstraintViolationException.class, MethodArgumentNotValidException.class})
+    protected ResponseEntity<?> constraintViolationException(ConstraintViolationException e) {
+//        log.error("MethodArgumentNotValidException", e);
+        ErrorResponse errorResponse = new ErrorResponse(DiaryExceptionType.INVALID_ID.getErrorCode(), DiaryExceptionType.INVALID_ID.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
+++ b/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
@@ -6,7 +6,7 @@ import com.sweep.jaksim31.dto.login.validator.LoginRequestValidator;
 import com.sweep.jaksim31.dto.member.*;
 import com.sweep.jaksim31.dto.member.validator.*;
 import com.sweep.jaksim31.exception.handler.ErrorResponse;
-import com.sweep.jaksim31.exception.type.DiaryExceptionType;
+import com.sweep.jaksim31.exception.type.MemberExceptionType;
 import com.sweep.jaksim31.service.impl.KakaoMemberServiceImpl;
 import com.sweep.jaksim31.service.impl.MemberServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -189,7 +189,7 @@ public class MembersApiController {
     @ExceptionHandler({ConstraintViolationException.class, MethodArgumentNotValidException.class})
     protected ResponseEntity<?> constraintViolationException(ConstraintViolationException e) {
 //        log.error("MethodArgumentNotValidException", e);
-        ErrorResponse errorResponse = new ErrorResponse(DiaryExceptionType.INVALID_ID.getErrorCode(), DiaryExceptionType.INVALID_ID.getMessage());
+        ErrorResponse errorResponse = new ErrorResponse(MemberExceptionType.INVALID_ID.getErrorCode(), MemberExceptionType.INVALID_ID.getMessage());
         return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
     }
 }

--- a/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
+++ b/src/main/java/com/sweep/jaksim31/controller/MembersApiController.java
@@ -5,6 +5,8 @@ import com.sweep.jaksim31.dto.login.LoginRequest;
 import com.sweep.jaksim31.dto.login.validator.LoginRequestValidator;
 import com.sweep.jaksim31.dto.member.*;
 import com.sweep.jaksim31.dto.member.validator.*;
+import com.sweep.jaksim31.exception.handler.ErrorResponse;
+import com.sweep.jaksim31.exception.type.DiaryExceptionType;
 import com.sweep.jaksim31.service.impl.KakaoMemberServiceImpl;
 import com.sweep.jaksim31.service.impl.MemberServiceImpl;
 import io.swagger.v3.oas.annotations.Operation;
@@ -16,11 +18,14 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.ConstraintViolationException;
+import javax.validation.constraints.Pattern;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -40,6 +45,7 @@ import java.net.URISyntaxException;
  * 2023-01-25           방근호             getMyInfoByLoginId 제거
  * 2023-01-27           김주현             자체 로그인, 로그아웃 응답 수정 redirect(3xx) => ok(200)
  * 2023-01-30           방근호             인증 로직으로 인한 메소드 수정
+ * 2023-02-01           김주현             PathValue(ObjectId_userId) validation 추가
  */
 
 /* TODO
@@ -52,7 +58,9 @@ import java.net.URISyntaxException;
 @RequiredArgsConstructor
 @Tag(name = "멤버", description = "멤버 관련 api 입니다.")
 @RequestMapping("/api")
+@Validated
 public class MembersApiController {
+    private final String idPattern = "^[a-zA-Z0-9]{24}$";
     private final MemberServiceImpl memberServiceImpl;
     private final KakaoMemberServiceImpl kaKaoMemberService;
     @Value("${kakao.auth.login-redirect-url}")
@@ -111,8 +119,8 @@ public class MembersApiController {
 
     @Operation(summary = "토큰 재발급", description = "리프레쉬 토큰으로 토큰을 재발급 합니다.")
     @PostMapping("/v1/members/{userId}/reissue")
-    public ResponseEntity<String> reissue(@PathVariable("userId") String userId, HttpServletRequest request,
-                            HttpServletResponse response
+    public ResponseEntity<String> reissue(@Pattern(regexp = idPattern) @PathVariable("userId") String userId, HttpServletRequest request,
+                                          HttpServletResponse response
     ) {
         memberServiceImpl.reissue(request, response);
         return ResponseEntity.ok("토큰이 재발급 되었습니다.");
@@ -129,21 +137,21 @@ public class MembersApiController {
 
     @Operation(summary = "개별 정보 조회", description = "자신의 정보를 요청합니다.")
     @GetMapping("/v1/members/{userId}")
-    public ResponseEntity<MemberInfoResponse> getMyInfo(@PathVariable("userId") String userId,
+    public ResponseEntity<MemberInfoResponse> getMyInfo(@Pattern(regexp = idPattern) @PathVariable("userId") String userId,
                                                         HttpServletRequest request) {
         return ResponseEntity.ok(memberServiceImpl.getMyInfo(userId,request));
     }
 
     @Operation(summary = "유저 정보 업데이트 요청", description = "유저 정보 업데이트를 요청합니다.")
     @PatchMapping("/v1/members/{userId}")
-    public ResponseEntity<String> updateMember(@PathVariable("userId") String userId,
+    public ResponseEntity<String> updateMember(@Pattern(regexp = idPattern) @PathVariable("userId") String userId,
                                                @Validated @RequestBody MemberUpdateRequest dto, HttpServletRequest request) {
         return ResponseEntity.ok(memberServiceImpl.updateMemberInfo(userId, dto,request));
     }
 
     @Operation(summary = "유저 삭제 요청", description = "유저 정보가 삭제됩니다.")
     @DeleteMapping("/v1/members/{userId}")
-    public ResponseEntity<String> remove(@PathVariable("userId") String userId,
+    public ResponseEntity<String> remove(@Pattern(regexp = idPattern) @PathVariable("userId") String userId,
                                          @Validated @RequestBody MemberRemoveRequest dto,
                                          HttpServletResponse response) throws URISyntaxException {
         URI redirectUri = new URI(logoutRedirectUrl);
@@ -176,4 +184,12 @@ public class MembersApiController {
         return new ResponseEntity<>(kaKaoMemberService.logout(request, response), httpHeaders, HttpStatus.SEE_OTHER);
     }
 
+    //Validator Exception Handler
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({ConstraintViolationException.class, MethodArgumentNotValidException.class})
+    protected ResponseEntity<?> constraintViolationException(ConstraintViolationException e) {
+//        log.error("MethodArgumentNotValidException", e);
+        ErrorResponse errorResponse = new ErrorResponse(DiaryExceptionType.INVALID_ID.getErrorCode(), DiaryExceptionType.INVALID_ID.getMessage());
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/src/main/java/com/sweep/jaksim31/dto/member/MemberInfoResponse.java
+++ b/src/main/java/com/sweep/jaksim31/dto/member/MemberInfoResponse.java
@@ -32,7 +32,7 @@ public class MemberInfoResponse {
     private String loginId;
     private String username;
     private String profileImage;
-    private DiaryInfoResponse recentDiaries;
+    private DiaryInfoResponse recentDiary;
     private int diaryTotal;
 
     public static MemberInfoResponse of(Members members) {

--- a/src/main/java/com/sweep/jaksim31/exception/type/DiaryExceptionType.java
+++ b/src/main/java/com/sweep/jaksim31/exception/type/DiaryExceptionType.java
@@ -29,6 +29,7 @@ public enum DiaryExceptionType implements BaseExceptionType {
     // 삭제 메소드 수행 시 존재 하지 않을 경우 200 응답
     DELETE_NOT_FOUND_DIARY("ALREADY_NOT_EXIST_DIARY", "존재하지 않는 일기입니다.", HttpStatus.OK),
     // Validation Exception type
+    INVALID_ID("INVALID_ID", "잘못 된 ID 값입니다.",HttpStatus.BAD_REQUEST),
     USER_ID_IS_NULL("USER_ID_IS_NULL", "사용자 ID가 입력되지 않았습니다.",HttpStatus.BAD_REQUEST),
     DIARY_ID_IS_NULL("DIARY_ID_IS_NULL", "Diary ID가 입력되지 않았습니다.",HttpStatus.BAD_REQUEST),
     CONTENT_IS_NULL("CONTENT_IS_NULL", "일기 내용이 입력되지 않았습니다.",HttpStatus.BAD_REQUEST),

--- a/src/main/java/com/sweep/jaksim31/exception/type/MemberExceptionType.java
+++ b/src/main/java/com/sweep/jaksim31/exception/type/MemberExceptionType.java
@@ -33,6 +33,7 @@ public enum MemberExceptionType implements BaseExceptionType {
     LOGOUT_MEMBER("LOGOUT_MEMBER","로그아웃된 사용자입니다.",HttpStatus.BAD_REQUEST),
     NO_PERMISSION("NO_PERMISSION", "권한이 없습니다.",HttpStatus.FORBIDDEN),
 
+    INVALID_ID("INVALID_ID", "잘못 된 ID 값입니다.",HttpStatus.BAD_REQUEST),
     SESSION_EXPIRED("SESSION_EXPIRED","세션이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
     DELETE_NOT_FOUND_USER("ALREADY_NOT_EXIST_MEMBER", "존재하지 않는 사용자입니다.", HttpStatus.SEE_OTHER);
 

--- a/src/main/java/com/sweep/jaksim31/service/impl/KakaoMemberServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/KakaoMemberServiceImpl.java
@@ -114,6 +114,7 @@ public class KakaoMemberServiceImpl implements MemberService {
         CookieUtil.addSecureCookie(response, "atk", accessToken, (int) rtkLive / 60);
         CookieUtil.addPublicCookie(response, "isLogin", "true", (int) rtkLive / 60);
         CookieUtil.addPublicCookie(response, "userId", members.getId(), (int) rtkLive / 60);
+        CookieUtil.addPublicCookie(response, "isSocial", members.getIsSocial().toString(), (int) rtkLive / 60);
 
         // 저장소 정보 업데이트
         refreshTokenCacheAdapter.put(authenticate.getName(), refreshToken, Duration.ofSeconds(rtkLive / 60));

--- a/src/main/java/com/sweep/jaksim31/service/impl/MemberServiceImpl.java
+++ b/src/main/java/com/sweep/jaksim31/service/impl/MemberServiceImpl.java
@@ -117,6 +117,7 @@ public class MemberServiceImpl implements MemberService {
         CookieUtil.addSecureCookie(response, "rtk", refreshToken, (int) rtkLive / 60);
         CookieUtil.addPublicCookie(response, "isLogin", "true", (int) rtkLive / 60);
         CookieUtil.addPublicCookie(response, "userId", members.getId(), (int) rtkLive / 60);
+        CookieUtil.addPublicCookie(response, "isSocial", members.getIsSocial().toString(), (int) rtkLive / 60);
 
         // 레디스에 캐싱
         refreshTokenCacheAdapter.put(loginId, refreshToken, Duration.ofSeconds((int) rtkLive / 60));
@@ -248,10 +249,10 @@ public class MemberServiceImpl implements MemberService {
      * @param userId 회원 아이디
      * @return MemberInfoResponse
      */
-    @Cacheable(
-            value = "memberCache",
-            key = "#userId"
-    )
+//    @Cacheable(
+//            value = "memberCache",
+//            key = "#userId"
+//    )
     @Transactional(readOnly = true)
     public MemberInfoResponse getMyInfo(String userId, HttpServletRequest request) {
         MemberInfoResponse members = memberRepository.findById(userId)

--- a/src/main/java/com/sweep/jaksim31/utils/CookieUtil.java
+++ b/src/main/java/com/sweep/jaksim31/utils/CookieUtil.java
@@ -90,6 +90,7 @@ public class CookieUtil {
         cookies.put("isLogin", "false");
         cookies.put("todayDiaryId", "");
         cookies.put("userId", "");
+        cookies.put("isSocial", "");
         for(String i : cookies.keySet()){
             ResponseCookie cookie = ResponseCookie.from(i, cookies.get(i))
                     .path("/")

--- a/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
@@ -327,6 +327,34 @@ public class DiaryApiControllerTest  {
                     .andExpect(jsonPath("$.thumbnail", Matchers.is("thumbnail")))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
+        @DisplayName("[예외]사용자 ID가 유효한 값이 아닌 경우")
+        @Test
+        void failFindDiaryInvaliUserId() throws Exception {
+            //when
+            mockMvc.perform(get("/api/v1/diaries/testobjectid1234/testobjectidtestobject12")
+                            .with(csrf()) //403 에러 방지
+                    )
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.INVALID_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.INVALID_ID.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+        @DisplayName("[예외]일기 ID가 유효한 값이 아닌 경우")
+        @Test
+        void failFindDiaryInvaliDiaryId() throws Exception {
+            //when
+            mockMvc.perform(get("/api/v1/diaries/testobjectidtestobject12/testobjectid1234")
+                            .with(csrf()) //403 에러 방지
+                    )
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.INVALID_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.INVALID_ID.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
         @Test
         @DisplayName("[예외]일기가 없는 경우")
         public void failFindDiaryNotFoundDiary() throws Exception{
@@ -470,6 +498,27 @@ public class DiaryApiControllerTest  {
                     .andExpect(jsonPath("$.thumbnail", Matchers.is("thumbnail")))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
+
+        @DisplayName("[예외]일기 ID가 유효한 값이 아닌 경우")
+        @Test
+        void failUpdateDiaryInvaliDiaryId() throws Exception {
+            //when
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectid1234", "contents", date, "happy", keywords,"thumbnail");
+            String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
+
+            //when
+            mockMvc.perform(put("/api/v1/diaries/testobjectid1234")
+                            .content(jsonRequest)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .with(csrf())) //403 에러 방지
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.INVALID_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.INVALID_ID.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
         @Test
         @DisplayName("[예외]사용자를 찾을 수 없을 때")
         public void failUpdateDiaryNotFoundUser() throws Exception{
@@ -647,6 +696,36 @@ public class DiaryApiControllerTest  {
                     .andExpect(content().string("diaryId"))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
+
+        @DisplayName("[예외]사용자 ID가 유효한 값이 아닌 경우")
+        @Test
+        void invalidRemoveInvaliUserId() throws Exception {
+            //when
+            mockMvc.perform(delete("/api/v1/diaries/testobjectid1234/testobjectidtestobject12")
+                            .with(csrf())) //403 에러 방지
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.INVALID_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.INVALID_ID.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
+
+        @DisplayName("[예외]일기 ID가 유효한 값이 아닌 경우")
+        @Test
+        void invalidRemoveInvaliDiaryId() throws Exception {
+            //when
+            mockMvc.perform(delete("/api/v1/diaries/testobjectidtestobject12/testobjectid1234")
+                            .with(csrf())) //403 에러 방지
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.INVALID_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.INVALID_ID.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
         @Test
         @DisplayName("[정상]일기 정보가 없을 때")
         public void removeDiaryNotFoundDiary() throws Exception{
@@ -923,6 +1002,21 @@ public class DiaryApiControllerTest  {
                     .andExpect(jsonPath("$.emotionStatics[0].countEmotion", Matchers.is(emotionStatics.get(0).getCountEmotion())))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
+
+        @DisplayName("[예외]일기 ID가 유효한 값이 아닌 경우")
+        @Test
+        void failEmotionStatisticsInvalidId() throws Exception {
+            //when
+            mockMvc.perform(get("/api/v1/diaries/testobjectid1234/emotions")
+                            .with(csrf())) //403 에러 방지
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(DiaryExceptionType.INVALID_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(DiaryExceptionType.INVALID_ID.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
         @Test
         @DisplayName("[정상]감정 통계 완료(날짜 조건이 있을 때)")
         public void emotionStatisticsWithDate() throws Exception{

--- a/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/DiaryApiControllerTest.java
@@ -62,6 +62,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *                      김주현             일기 삭제 service 수정으로 인한 test 코드 수정
  * 2023-01-27           김주현             validator 테스트 코드 추가
  *                                       중복 코드 제거
+ * 2023-02-01           김주현             PathValue validation 추가로 인한 test 수정
  */
 
 @WebMvcTest(controllers = DiaryApiController.class)
@@ -104,7 +105,7 @@ public class DiaryApiControllerTest  {
             //given
             given(diaryService.saveDiary(any()))
                     .willReturn(DiaryResponse.builder()
-                            .userId("63c0cb6f30dc3d547e3b88bb")
+                            .userId("testobjectidtestobject12")
                             .content("contents")
                             .diaryDate(date)
                             .modifyDate(LocalDate.now())
@@ -114,7 +115,7 @@ public class DiaryApiControllerTest  {
                             .build());
 
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/api/v1/diaries")
@@ -125,7 +126,7 @@ public class DiaryApiControllerTest  {
                     //then
                     .andExpect(status().isCreated())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.userId", Matchers.is("63c0cb6f30dc3d547e3b88bb")))
+                    .andExpect(jsonPath("$.userId", Matchers.is("testobjectidtestobject12")))
                     .andExpect(jsonPath("$.content", Matchers.is("contents")))
                     .andExpect(jsonPath("$.diaryDate", Matchers.is(date.toString())))
                     .andExpect(jsonPath("$.modifyDate", Matchers.is(LocalDate.now().toString())))
@@ -142,7 +143,7 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(MemberExceptionType.NOT_FOUND_USER));
 
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/api/v1/diaries")
@@ -164,7 +165,7 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(DiaryExceptionType.DUPLICATE_DIARY));
 
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/api/v1/diaries")
@@ -200,7 +201,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[예외]일기 내용이 입력되지 않았을 때")
         public void failSaveDiaryContentIsNULL() throws Exception{
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/api/v1/diaries")
@@ -218,7 +219,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[예외]감정 분석 결과가 입력되지 않았을 때")
         public void failSaveDiaryEmotionIsNULL() throws Exception{
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/api/v1/diaries")
@@ -237,7 +238,7 @@ public class DiaryApiControllerTest  {
         public void failSaveDiaryKeywordIsEmpty() throws Exception{
             String[] empty_keywords = new String[0];
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", empty_keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", empty_keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/api/v1/diaries")
@@ -255,7 +256,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[예외]썸네일 주소가 입력되지 않았을 때")
         public void failSaveDiaryThumbnailIsNULL() throws Exception{
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/api/v1/diaries")
@@ -274,7 +275,7 @@ public class DiaryApiControllerTest  {
         public void failSaveDiaryWrongDate() throws Exception{
             date = LocalDate.now().plusDays(1);
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(post("/api/v1/diaries")
@@ -299,7 +300,7 @@ public class DiaryApiControllerTest  {
         public void findDiary() throws Exception{
             DiaryResponse diary = DiaryResponse.builder()
                     .diaryId("diaryId")
-                    .userId("userId")
+                    .userId("testobjectidtestobject12")
                     .diaryDate(date)
                     .modifyDate(LocalDate.now())
                     .emotion("happy")
@@ -311,14 +312,14 @@ public class DiaryApiControllerTest  {
                     .willReturn(diary);
 
             //when
-            mockMvc.perform(get("/api/v1/diaries/userId/diaryId")
+            mockMvc.perform(get("/api/v1/diaries/testobjectidtestobject12/testobjectidtestobject12")
                             .with(csrf()) //403 에러 방지
                     )
 
                     //then
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.userId", Matchers.is("userId")))
+                    .andExpect(jsonPath("$.userId", Matchers.is("testobjectidtestobject12")))
                     .andExpect(jsonPath("$.diaryDate", Matchers.is(date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))))
                     .andExpect(jsonPath("$.modifyDate", Matchers.is(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))))
                     .andExpect(jsonPath("$.emotion", Matchers.is("happy")))
@@ -334,7 +335,7 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(DiaryExceptionType.NOT_FOUND_DIARY));
 
             //when
-            mockMvc.perform(get("/api/v1/diaries/userId/diaryId")
+            mockMvc.perform(get("/api/v1/diaries/testobjectidtestobject12/testobjectidtestobject12")
                             .with(csrf()) //403 에러 방지
                     )
 
@@ -353,7 +354,7 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(DiaryExceptionType.NO_PERMISSION));
 
             //when
-            mockMvc.perform(get("/api/v1/diaries/userId/diaryId")
+            mockMvc.perform(get("/api/v1/diaries/testobjectidtestobject12/testobjectidtestobject12")
                             .with(csrf()) //403 에러 방지
                     )
 
@@ -375,7 +376,7 @@ public class DiaryApiControllerTest  {
         public void findUserDiaries() throws Exception{
             List<DiaryInfoResponse> diaryInfoResponses = List.of(DiaryInfoResponse.builder()
                     .diaryId("diaryId")
-                    .userId("userId")
+                    .userId("testobjectidtestobject12")
                     .diaryDate(date)
                     .modifyDate(LocalDate.now())
                     .emotion("happy")
@@ -389,7 +390,7 @@ public class DiaryApiControllerTest  {
                     .willReturn(new RestPage<>(page));
 
             //when
-            mockMvc.perform(get("/api/v1/diaries/userId")
+            mockMvc.perform(get("/api/v1/diaries/testobjectidtestobject12")
                             .with(csrf()) //403 에러 방지
                             .queryParam("page", String.valueOf(0))
                     )
@@ -397,7 +398,7 @@ public class DiaryApiControllerTest  {
                     //then
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.content[0].userId", Matchers.is("userId")))
+                    .andExpect(jsonPath("$.content[0].userId", Matchers.is("testobjectidtestobject12")))
                     .andExpect(jsonPath("$.content[0].diaryDate", Matchers.is(date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))))
                     .andExpect(jsonPath("$.content[0].modifyDate", Matchers.is(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))))
                     .andExpect(jsonPath("$.content[0].emotion", Matchers.is("happy")))
@@ -414,7 +415,7 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(MemberExceptionType.NOT_FOUND_USER));
 
             //when
-            mockMvc.perform(get("/api/v1/diaries/userId")
+            mockMvc.perform(get("/api/v1/diaries/testobjectidtestobject12")
                             .with(csrf()) //403 에러 방지
                             .queryParam("page", String.valueOf(0))
                     )
@@ -439,7 +440,7 @@ public class DiaryApiControllerTest  {
             //given
             given(diaryService.updateDiary(any(), any()))
                     .willReturn(
-                            DiaryResponse.of(new Diary("diaryId", DiarySaveRequest.builder().userId("userId")
+                            DiaryResponse.of(new Diary("testobjectidtestobject12", DiarySaveRequest.builder().userId("testobjectidtestobject12")
                                     .content("contents")
                                     .date(date)
                                     .emotion("happy")
@@ -448,10 +449,10 @@ public class DiaryApiControllerTest  {
                                     .build())));
 
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("userId", "contents", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
-            mockMvc.perform(put("/api/v1/diaries/diaryId")
+            mockMvc.perform(put("/api/v1/diaries/testobjectidtestobject12")
                             .with(csrf()) //403 에러 방지
                             .content(jsonRequest)
                             .contentType(MediaType.APPLICATION_JSON))
@@ -459,8 +460,8 @@ public class DiaryApiControllerTest  {
                     //then
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                    .andExpect(jsonPath("$.diaryId", Matchers.is("diaryId")))
-                    .andExpect(jsonPath("$.userId", Matchers.is("userId")))
+                    .andExpect(jsonPath("$.diaryId", Matchers.is("testobjectidtestobject12")))
+                    .andExpect(jsonPath("$.userId", Matchers.is("testobjectidtestobject12")))
                     .andExpect(jsonPath("$.content", Matchers.is("contents")))
                     .andExpect(jsonPath("$.diaryDate", Matchers.is(date.toString())))
                     .andExpect(jsonPath("$.modifyDate", Matchers.is(LocalDate.now().toString())))
@@ -477,10 +478,10 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(MemberExceptionType.NOT_FOUND_USER));
 
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("userId", "contents", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
-            mockMvc.perform(put("/api/v1/diaries/diaryId")
+            mockMvc.perform(put("/api/v1/diaries/testobjectidtestobject12")
                     .with(csrf()) //403 에러 방지
                     .content(jsonRequest)
                     .contentType(MediaType.APPLICATION_JSON))
@@ -500,10 +501,10 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(DiaryExceptionType.NOT_FOUND_DIARY));;
 
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("userId", "contents", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
-            mockMvc.perform(put("/api/v1/diaries/diaryId")
+            mockMvc.perform(put("/api/v1/diaries/testobjectidtestobject12")
                             .with(csrf()) //403 에러 방지
                             .content(jsonRequest)
                             .contentType(MediaType.APPLICATION_JSON))
@@ -536,7 +537,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[예외]일기 내용이 입력되지 않았을 때")
         public void failUpdateDiaryContentIsNULL() throws Exception{
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(put("/api/v1/diaries/diaryId")
@@ -554,7 +555,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[예외]감정 분석 결과가 입력되지 않았을 때")
         public void failUpdateDiaryEmotionIsNULL() throws Exception{
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(put("/api/v1/diaries/diaryId")
@@ -573,7 +574,7 @@ public class DiaryApiControllerTest  {
         public void failUpdateDiaryKeywordIsEmpty() throws Exception{
             String[] empty_keywords = new String[0];
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", empty_keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", empty_keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(put("/api/v1/diaries/diaryId")
@@ -591,7 +592,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[예외]썸네일 주소가 입력되지 않았을 때")
         public void failUpdateDiaryThumbnailIsNULL() throws Exception{
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(put("/api/v1/diaries/diaryId")
@@ -610,7 +611,7 @@ public class DiaryApiControllerTest  {
         public void failUpdateDiaryWrongDate() throws Exception{
             date = LocalDate.now().plusDays(1);
             //when
-            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("63c0cb6f30dc3d547e3b88bb", "contents", date, "happy", keywords,"thumbnail");
+            DiarySaveRequest diarySaveRequest = new DiarySaveRequest("testobjectidtestobject12", "contents", date, "happy", keywords,"thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diarySaveRequest);
 
             mockMvc.perform(put("/api/v1/diaries/diaryId")
@@ -636,7 +637,7 @@ public class DiaryApiControllerTest  {
                     .willReturn("diaryId");
 
             //when
-            mockMvc.perform(delete("/api/v1/diaries/userId/diaryId")
+            mockMvc.perform(delete("/api/v1/diaries/testobjectidtestobject12/testobjectidtestobject12")
                             .with(csrf()) //403 에러 방지
                     )
 
@@ -654,7 +655,7 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(DiaryExceptionType.DELETE_NOT_FOUND_DIARY));
 
             //when
-            mockMvc.perform(delete("/api/v1/diaries/userId/diaryId")
+            mockMvc.perform(delete("/api/v1/diaries/testobjectidtestobject12/testobjectidtestobject12")
                             .with(csrf()) //403 에러 방지
                     )
 
@@ -802,10 +803,10 @@ public class DiaryApiControllerTest  {
             DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'");
             //given
             given(diaryService.saveThumbnail(any()))
-                    .willReturn("downloadUrl/userId/"+ DATE_FORMATTER.format(ZonedDateTime.now()) + "_r_640x0_100_0_0.png");
+                    .willReturn("downloadUrl/testobjectidtestobject12/"+ DATE_FORMATTER.format(ZonedDateTime.now()) + "_r_640x0_100_0_0.png");
 
             //when
-            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId","diaryId","thumbnail");
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("testobjectidtestobject12","diaryId","thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
 
             mockMvc.perform(put("/api/v1/diaries/thumbnail")
@@ -815,7 +816,7 @@ public class DiaryApiControllerTest  {
                     //then
                     .andExpect(status().isOk())
                     .andExpect(content().contentType("text/plain;charset=UTF-8"))
-                    .andExpect(content().string("downloadUrl/userId/"+ DATE_FORMATTER.format(ZonedDateTime.now()) + "_r_640x0_100_0_0.png"))
+                    .andExpect(content().string("downloadUrl/testobjectidtestobject12/"+ DATE_FORMATTER.format(ZonedDateTime.now()) + "_r_640x0_100_0_0.png"))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
         @Test
@@ -827,7 +828,7 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(ThirdPartyExceptionType.NOT_UPLOAD_IMAGE));
 
             //when
-            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId","diaryId","thumbnail");
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("testobjectidtestobject12","diaryId","thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
 
             mockMvc.perform(put("/api/v1/diaries/thumbnail")
@@ -863,7 +864,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[예외]일기 ID가 입력되지 않았을 때")
         public void failSaveThumbnailDiaryIdIsNULL() throws Exception{
             //when
-            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId","","thumbnail");
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("testobjectidtestobject12","","thumbnail");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
 
             mockMvc.perform(put("/api/v1/diaries/thumbnail")
@@ -881,7 +882,7 @@ public class DiaryApiControllerTest  {
         @DisplayName("[예외]썸네일 이미지 경로가 입력되지 않았을 때")
         public void failSaveThumbnailURIIsNULL() throws Exception{
             //when
-            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("userId","diaryId","");
+            DiaryThumbnailRequest diaryThumbnailRequest = new DiaryThumbnailRequest("testobjectidtestobject12","testobjectidtestobject12","");
             String jsonRequest = JsonUtil.objectMapper.writeValueAsString(diaryThumbnailRequest);
 
             mockMvc.perform(put("/api/v1/diaries/thumbnail")
@@ -913,7 +914,7 @@ public class DiaryApiControllerTest  {
                                     .build());
 
             //when
-            mockMvc.perform(get("/api/v1/diaries/userId/emotions")
+            mockMvc.perform(get("/api/v1/diaries/testobjectidtestobject12/emotions")
                             .with(csrf())) //403 에러 방지
                     //then
                     .andExpect(status().isOk())
@@ -940,7 +941,7 @@ public class DiaryApiControllerTest  {
                             .build());
 
             //when
-            mockMvc.perform(get("/api/v1/diaries/userId/emotions?startDate=2023-01-01&endDate=2023-01-20")
+            mockMvc.perform(get("/api/v1/diaries/testobjectidtestobject12/emotions?startDate=2023-01-01&endDate=2023-01-20")
                             .with(csrf())) //403 에러 방지
                     //then
                     .andExpect(status().isOk())
@@ -962,7 +963,7 @@ public class DiaryApiControllerTest  {
                     .willThrow(new BizException(MemberExceptionType.NOT_FOUND_USER));
 
             //when
-            mockMvc.perform(get("/api/v1/diaries/userId/emotions?startDate=2023-01-01&endDate=2023-01-10")
+            mockMvc.perform(get("/api/v1/diaries/testobjectidtestobject12/emotions?startDate=2023-01-01&endDate=2023-01-10")
                             .with(csrf())) //403 에러 방지
                     //then
                     .andExpect(status().is4xxClientError())

--- a/src/test/java/com/sweep/jaksim31/controller/MemberApiControllerNullTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/MemberApiControllerNullTest.java
@@ -38,6 +38,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-27              김주현             최초 생성
+ * 2023-02-01           김주현                PathValue validation 추가로 인한 test 수정
  */
 
 @WebMvcTest(controllers = MembersApiController.class)
@@ -208,7 +209,7 @@ class MemberApiControllerNullTest {
         @DisplayName("토큰 값이 비어있는 경우")
         void invalidReissueEmptyToken() throws Exception {
             //when
-            mockMvc.perform(post("/api/v1/members/geunho/reissue")
+            mockMvc.perform(post("/api/v1/members/testobjectidtestobject12/reissue")
                             .with(csrf()) //403 에러 방지
                             .contentType(MediaType.APPLICATION_JSON))
                     //then

--- a/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
@@ -49,6 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  * 2023-01-27           김주현             로그인 응답 코드 변경에 따른 test코드 수정
  * 2023-01-30           방근호             인증 로직 변경으로 인한 test 수정 및 제거
  * 2023-01-31           김주현             사용자 정보 조회, 수정 service 수정으로 인한 테스트 코드 수정
+ * 2023-02-01           김주현             PathValue validation 추가로 인한 test 수정
  */
 
 @WebMvcTest(controllers = MembersApiController.class)
@@ -292,7 +293,7 @@ class MembersApiControllerTest {
 //            given(memberService.reissue(any(), any()))
 //                    .willReturn();
             //when
-            mockMvc.perform(post("/api/v1/members/geunho/reissue")
+            mockMvc.perform(post("/api/v1/members/testobjectidtestobject12/reissue")
                             .with(csrf()) //403 에러 방지
                             .contentType(MediaType.APPLICATION_JSON))
                     //then
@@ -308,7 +309,7 @@ class MembersApiControllerTest {
 //                    .willReturn("토큰 재발급이 완료되었습니다.");
 
             //when
-            mockMvc.perform(post("/api/v1/members/geunho/reissue")
+            mockMvc.perform(post("/api/v1/members/testobjectidtestobject12/reissue")
                             .with(csrf()) //403 에러 방지
                             .contentType(MediaType.APPLICATION_JSON))
                     //then
@@ -321,7 +322,7 @@ class MembersApiControllerTest {
 //        @DisplayName("토큰 값이 비어있는 경우")
 //        void invalidReissueEmptyToken() throws Exception {
 //            //when
-//            mockMvc.perform(post("/api/v0/members/geunho/reissue")
+//            mockMvc.perform(post("/api/v0/members/testobjectidtestobject12/reissue")
 //                            .with(csrf()) //403 에러 방지
 //                            .contentType(MediaType.APPLICATION_JSON))
 //                    //then
@@ -490,7 +491,7 @@ class MembersApiControllerTest {
                             .build());
 
             //when
-            mockMvc.perform(get("/api/v1/members/geunho")
+            mockMvc.perform(get("/api/v1/members/testobjectidtestobject12")
                             .with(csrf()))
                     .andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON))
@@ -499,7 +500,7 @@ class MembersApiControllerTest {
                     .andExpect(jsonPath("$.username", Matchers.is("username")))
                     .andExpect(jsonPath("$.profileImage", Matchers.is("profileImage")))
                     .andExpect(jsonPath("$.diaryTotal", Matchers.is(10)))
-                    .andExpect(jsonPath("$.recentDiaries", Matchers.nullValue()))
+                    .andExpect(jsonPath("$.recentDiary", Matchers.nullValue()))
                     .andDo(MockMvcResultHandlers.print(System.out));
 
         }
@@ -512,7 +513,7 @@ class MembersApiControllerTest {
                     .willThrow(new BizException(MemberExceptionType.NOT_FOUND_USER));
 
             //when
-            mockMvc.perform(get("/api/v1/members/geunho")
+            mockMvc.perform(get("/api/v1/members/testobjectidtestobject12")
                             .with(csrf())) //403 에러 방지
 
                     //then
@@ -539,7 +540,7 @@ class MembersApiControllerTest {
             MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("방근호", "프로필이미지");
             String jsonString = JsonUtil.objectMapper.writeValueAsString(memberUpdateRequest);
 
-            mockMvc.perform(patch("/api/v1/members/geunho")
+            mockMvc.perform(patch("/api/v1/members/testobjectidtestobject12")
                             .with(csrf())
                             .content(jsonString)
                             .contentType(MediaType.APPLICATION_JSON))
@@ -561,7 +562,7 @@ class MembersApiControllerTest {
             MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("방근호", "프로필이미지");
             String jsonString = JsonUtil.objectMapper.writeValueAsString(memberUpdateRequest);
 
-            mockMvc.perform(patch("/api/v1/members/geunho")
+            mockMvc.perform(patch("/api/v1/members/testobjectidtestobject12")
                             .with(csrf())
                             .content(jsonString)
                             .contentType(MediaType.APPLICATION_JSON))
@@ -586,10 +587,10 @@ class MembersApiControllerTest {
             given(memberService.remove(any(), any(), any()))
                     .willReturn("삭제되었습니다.");
 
-            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("geunho", "geunho");
+            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("testobjectidtestobject12", "geunho");
             String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
 
-            mockMvc.perform(delete("/api/v1/members/geunho")
+            mockMvc.perform(delete("/api/v1/members/testobjectidtestobject12")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(jsonString))
@@ -607,10 +608,10 @@ class MembersApiControllerTest {
             given(memberService.remove(any(), any(), any()))
                     .willThrow(new BizException(MemberExceptionType.DELETE_NOT_FOUND_USER, "test"));
 
-            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("geunho", "geunho");
+            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("testobjectidtestobject12", "geunho");
             String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
 
-            mockMvc.perform(delete("/api/v1/members/geunho")
+            mockMvc.perform(delete("/api/v1/members/testobjectidtestobject12")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(jsonString))
@@ -630,10 +631,10 @@ class MembersApiControllerTest {
             given(memberService.remove(any(), any(), any()))
                     .willThrow(new BizException(MemberExceptionType.WRONG_PASSWORD));
 
-            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("geunho", "geunho");
+            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("testobjectidtestobject12", "geunho");
             String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
 
-            mockMvc.perform(delete("/api/v1/members/geunho")
+            mockMvc.perform(delete("/api/v1/members/testobjectidtestobject12")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(jsonString))
@@ -651,7 +652,7 @@ class MembersApiControllerTest {
             MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("", "geunho");
             String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
 
-            mockMvc.perform(delete("/api/v1/members/geunho")
+            mockMvc.perform(delete("/api/v1/members/testobjectidtestobject12")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(jsonString))
@@ -666,10 +667,10 @@ class MembersApiControllerTest {
         @Test
         void invalidRemoveMemberNotFoundPassword() throws Exception {
             //when
-            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("geunho", "");
+            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("testobjectidtestobject12", "");
             String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
 
-            mockMvc.perform(delete("/api/v1/members/geunho")
+            mockMvc.perform(delete("/api/v1/members/testobjectidtestobject12")
                             .with(csrf())
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(jsonString))
@@ -845,7 +846,7 @@ class MembersApiControllerTest {
 
                     //then
                     .andExpect(status().is3xxRedirection())
-                    .andExpect(header().string("Location", "http://localhost:3000"))
+                    .andExpect(header().string("Location", "http://localhost:3000/diary/dashboard"))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
     }

--- a/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
+++ b/src/test/java/com/sweep/jaksim31/controller/MembersApiControllerTest.java
@@ -505,6 +505,19 @@ class MembersApiControllerTest {
 
         }
 
+        @DisplayName("User ID가 유효한 값이 아닌 경우")
+        @Test
+        void invalidGetMyInfoInvalidId() throws Exception {
+            mockMvc.perform(get("/api/v1/members/testobjectid1234")
+                            .with(csrf())) //403 에러 방지
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.INVALID_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.INVALID_ID.getErrorCode())))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
         @DisplayName("해당 유저가 없는 경우")
         @Test
         void invalidGetMyInfoByUserId() throws Exception {
@@ -549,6 +562,25 @@ class MembersApiControllerTest {
                     .andExpect(status().isOk())
                     .andExpect(content().contentType("text/plain;charset=UTF-8"))
                     .andExpect(content().string("회원 정보가 변경 되었습니다."))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
+        @DisplayName("User ID가 유효한 값이 아닌 경우")
+        @Test
+        void invalidUpdateMemberInvalidId() throws Exception {
+            //when
+            MemberUpdateRequest memberUpdateRequest = new MemberUpdateRequest("방근호", "프로필이미지");
+            String jsonString = JsonUtil.objectMapper.writeValueAsString(memberUpdateRequest);
+
+            mockMvc.perform(patch("/api/v1/members/testobjectid1234")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonString))
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.INVALID_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.INVALID_ID.getErrorCode())))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
 
@@ -598,6 +630,25 @@ class MembersApiControllerTest {
                     .andExpect(status().is3xxRedirection())
                     .andExpect(content().contentType("text/plain;charset=UTF-8"))
                     .andExpect(content().string("삭제되었습니다."))
+                    .andDo(MockMvcResultHandlers.print(System.out));
+        }
+
+        @DisplayName("User ID가 유효한 값이 아닌 경우")
+        @Test
+        void invalidRemoveInvalidId() throws Exception {
+
+            MemberRemoveRequest memberRemoveRequest = new MemberRemoveRequest("testobjectid1234", "geunho");
+            String jsonString = JsonUtil.objectMapper.writeValueAsString(memberRemoveRequest);
+
+            mockMvc.perform(delete("/api/v1/members/testobjectid1234")
+                            .with(csrf())
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(jsonString))
+
+                    .andExpect(status().is4xxClientError())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(jsonPath("$.errorMessage", Matchers.is(MemberExceptionType.INVALID_ID.getMessage())))
+                    .andExpect(jsonPath("$.errorCode", Matchers.is(MemberExceptionType.INVALID_ID.getErrorCode())))
                     .andDo(MockMvcResultHandlers.print(System.out));
         }
 

--- a/src/test/java/com/sweep/jaksim31/integration/IntegrationMemberTest.java
+++ b/src/test/java/com/sweep/jaksim31/integration/IntegrationMemberTest.java
@@ -36,10 +36,10 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 /**
  * packageName :  com.sweep.jaksim31.Integration
- * fileName : IntegrationTest
+ * fileName : IntegrationMemberTest
  * author :  김주현
  * date : 2023-01-28
- * description : 통합테스트
+ * description : Member service 통합테스트
  * ===========================================================
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------


### PR DESCRIPTION
- 사용자 로그인/로그아웃 시 Cookie에 `isSocial` 설정

- recentDiaries -> recentDiary
> MemberInfoResponse, MembersApiControllerTest

- DiaryServiceImpl : 마지막 남은 일기 삭제 시 recentDiary 설정 오류 수정

- ObjectId validation 추가
> MembersApiController, DiaryApiController : PathValues userId, diaryId(MongoDB ObjectId) 유효성 검사 및 ExceptionHandler 추가
> 테스트 코드 수정 : MembersApiControllerTest, MemberApiControllerNullTest, DiaryApiControllerTest

- MemberExceptionType : 유효한 id 값이 아닌 경우`INVALID_ID` 추가

- ID 유효성 검사 테스트 코드 추가
> MembersApiControllerTest, DiaryApiControllerTest