### PR TITLE
SW-146 modify github action workflow & split cache config into local …

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -91,26 +91,83 @@ jobs:
           name: target
           path: target/*.jar
 
-      - name: (PR) Write the testing result on PR
+      - name: (PR) Archive test results artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-result
+          path: target/surefire-reports/
+
+      - name: (PR) Archive test results artifacts
+        if: github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v3
+        with:
+          name: classes
+          path: target/classes/
+
+  Report-Test-Result:
+    if: github.event_name == 'pull_request'
+    needs: Backend-CI
+    # macos 환경에서 CI 실행 (환경은 github이 제공)
+    runs-on: ubuntu-latest
+    # 각 단계
+    steps:
+      # 이전 Job에서 업로드한 Jar file 다운로드
+      - name: Download a test result
+        uses: actions/download-artifact@v1
+        with:
+          name: test-result
+
+      - name: Write the testing result on PR
         uses: EnricoMi/publish-unit-test-result-action/composite@v2
         if: always() && github.event_name == 'pull_request'
         with:
-          junit_files: '**/target/surefire-reports/TEST-*.xml'
+          junit_files: '**/test-result/TEST-*.xml'
           comment_title: 'Jaksim31 Unit & Integration Test Results'
+          token: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}
 
-      - name: (PR) Check Comment on the Code line.
+      - name: Check Comment on the Code line.
         uses: mikepenz/action-junit-report@v3
         if: always() && github.event_name == 'pull_request'
         with:
-          report_paths: '**/target/surefire-reports/TEST-*.xml'
+          report_paths: '**/test-result/TEST-*.xml'
           token: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}
 
-      # 위에서 설정했던 정적코드 전송 태스크 실행
-      - name: (PR) Sonarqube Analysis
-        if: always() && github.event_name == 'pull_request'
-        run: ./mvnw sonar:sonar -Dsonar.host.url=${{ env.SONARQUBE_URL }} -Dsonar.projectKey=${{ env.SONARQUBE_ID }} -Dsonar.projectName=${{ env.SONARQUBE_ID }}-${{ env.PR_NUMBER }} -Dsonar.login=${{ secrets.SONARQUBE_ACCESS_TOKEN }}
 
-      - name: (PR) Comment Sonarqube URL
+  Sonarqube-Analysis:
+    if: github.event_name == 'pull_request'
+    needs: Backend-CI
+    env:
+      # KEY - VALUE
+      SONARQUBE_ID: jaksim31
+      SONARQUBE_URL: ${{ secrets.SONARQUBE_URL }}
+      SONARQUBE_BINARIES: classes
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      # macos 환경에서 CI 실행 (환경은 github이 제공)
+    runs-on: ubuntu-latest
+    # 각 단계
+    steps:
+      # 소스코드 가져오기
+      - name: Checkout source code
+        uses: actions/checkout@v2
+        # 서브모듈 설정
+        with:
+          submodules: true
+          # secrets 변수는 github 세팅에서 미리 세팅한 데이터
+          token: ${{ secrets.SUBMODULE_ACCESS_TOKEN }}
+
+      # 이전 Job에서 업로드한 Jar file 다운로드
+      - name: Download a test result
+        uses: actions/download-artifact@v1
+        with:
+          name: classes
+
+      # 위에서 설정했던 정적코드 전송 태스크 실행
+      - name: Sonarqube Analysis
+        if: always() && github.event_name == 'pull_request'
+        run: ./mvnw sonar:sonar -Dsonar.java.binaries=${{ env.SONARQUBE_BINARIES }} -Dsonar.host.url=${{ env.SONARQUBE_URL }} -Dsonar.projectKey=${{ env.SONARQUBE_ID }} -Dsonar.projectName=${{ env.SONARQUBE_ID }}-${{ env.PR_NUMBER }} -Dsonar.login=${{ secrets.SONARQUBE_ACCESS_TOKEN }}
+
+      - name: Comment Sonarqube URL
         if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v4
         with:
@@ -166,7 +223,9 @@ jobs:
           file: ./Dockerfile
           platforms: linux/amd64
           push: true
-          tags: qkdrmsgh73/jaksim31-backend:latest
+          tags: |
+            ${{ secrets.DOCKER_ID }}/jaksim31-backend:$(date +%s)
+            ${{ secrets.DOCKER_ID }}/jaksim31-backend:latest
           cache-from: type=gha    # gha=Github Action Cache
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -98,7 +98,7 @@ jobs:
           name: test-result
           path: target/surefire-reports/
 
-      - name: (PR) Archive test results artifacts
+      - name: (PR) Archive classes artifacts
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v3
         with:

--- a/src/main/java/com/sweep/jaksim31/config/SwaggerConfig.java
+++ b/src/main/java/com/sweep/jaksim31/config/SwaggerConfig.java
@@ -2,6 +2,7 @@ package com.sweep.jaksim31.config;
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
 
+import io.swagger.v3.oas.annotations.servers.Server;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
@@ -20,10 +21,14 @@ import org.springframework.context.annotation.Configuration;
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-13           방근호             최초 생성
+ * 2023-02-06           방근호             테스트용 URL 추가
  *
  */
 
 @OpenAPIDefinition(
+        servers = {@Server(url = "http://localhost:8080"),
+                   @Server(url = "https://jaksim31.xyz")},
+
         info = @Info(
                 title = "Jaksim31 API",
                 description = "일기관리 서비스 \"작심상일\" API 명세서",

--- a/src/main/java/com/sweep/jaksim31/config/WebConfig.java
+++ b/src/main/java/com/sweep/jaksim31/config/WebConfig.java
@@ -14,6 +14,7 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * DATE                 AUTHOR                NOTE
  * -----------------------------------------------------------
  * 2023-01-13           방근호             최초 생성
+ * 2023-02-06           방근호             CORS 정책 수정
  *
  */
 
@@ -22,24 +23,10 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry){
-        registry.addMapping("localhost:3000")
-                .allowedOrigins("*")
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000", "https://jaksim31.xyz", "http://jaksim31.xyz")
                 .allowedMethods("*")
                 .allowedHeaders("*")
                 .allowCredentials(true);
     }
 }
-
-
-
-//@Configuration
-//public class WebConfig implements WebMvcConfigurer {
-//    @Override
-//    public void addCorsMappings(CorsRegistry registry){
-//        registry.addMapping("/**")
-//                .allowedOrigins("http://localhost:3000", "https://jaksim31.xyz", "http://jaksim31.xyz")
-//                .allowedMethods("*")
-//                .allowedHeaders("*")
-//                .allowCredentials(true);
-//    }
-//}

--- a/src/main/java/com/sweep/jaksim31/config/cache/LocalCacheConfig.java
+++ b/src/main/java/com/sweep/jaksim31/config/cache/LocalCacheConfig.java
@@ -1,4 +1,4 @@
-package com.sweep.jaksim31.config;
+package com.sweep.jaksim31.config.cache;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -20,6 +20,7 @@ import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
@@ -28,7 +29,10 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.*;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
 import java.util.HashMap;
@@ -37,7 +41,8 @@ import java.util.Map;
 
 @Configuration
 @EnableCaching
-public class CacheConfig {
+@Profile("local")
+public class LocalCacheConfig {
 
     @Value("${spring.redis.host}")
     private String host;

--- a/src/main/java/com/sweep/jaksim31/config/cache/ProdCacheConfig.java
+++ b/src/main/java/com/sweep/jaksim31/config/cache/ProdCacheConfig.java
@@ -1,0 +1,136 @@
+package com.sweep.jaksim31.config.cache;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.sweep.jaksim31.adapter.RestPage;
+import com.sweep.jaksim31.adapter.cache.DiaryCacheSerializer;
+import com.sweep.jaksim31.adapter.cache.DiaryPagingCacheSerializer;
+import com.sweep.jaksim31.adapter.cache.MemberCacheSerializer;
+import com.sweep.jaksim31.dto.diary.DiaryInfoResponse;
+import com.sweep.jaksim31.dto.diary.DiaryResponse;
+import com.sweep.jaksim31.dto.member.MemberInfoResponse;
+import io.lettuce.core.ReadFrom;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisStaticMasterReplicaConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+@Profile("prod")
+@Configuration
+@RequiredArgsConstructor
+public class ProdCacheConfig {
+    private final RedisInfo info;
+
+    @Bean
+    public LettuceConnectionFactory redisConnectionFactory(){
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .readFrom(ReadFrom.REPLICA_PREFERRED)	// replica에서 우선적으로 읽지만 replica에서 읽어오지 못할 경우 Master에서 읽어옴
+                .build();
+        // replica 설정
+        RedisStaticMasterReplicaConfiguration slaveConfig = new RedisStaticMasterReplicaConfiguration(info.getMaster().getHost(), info.getMaster().getPort());
+        // 설정에 slave 설정 값 추가
+        info.getSlaves().forEach(slave -> slaveConfig.addNode(slave.getHost(), slave.getPort()));
+        return new LettuceConnectionFactory(slaveConfig, clientConfig);
+    }
+
+    @Bean
+    public RedisTemplate<String, RestPage<DiaryInfoResponse>> diaryPageCacheRedisTemplate() {
+        RedisTemplate<String, RestPage<DiaryInfoResponse>> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new DiaryPagingCacheSerializer());
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, DiaryResponse> diaryCacheRedisTemplate() {
+        RedisTemplate<String, DiaryResponse> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new DiaryCacheSerializer());
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, String> refreshTokenCacheRedisTemplate() {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+
+        return redisTemplate;
+    }
+
+    @Bean
+    public RedisTemplate<String, MemberInfoResponse> memberCacheRedisTemplate() {
+        RedisTemplate<String, MemberInfoResponse> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new MemberCacheSerializer());
+
+        return redisTemplate;
+    }
+
+
+    //     jackson LocalDateTime mapper
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.findAndRegisterModules();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // timestamp 형식 안따르도록 설정
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        mapper.registerModules(new JavaTimeModule(), new Jdk8Module()); // LocalDateTime 매핑을 위해 모듈 활성화
+
+        return mapper;
+    }
+
+    @Bean
+    public CacheManager cacheManager() {
+        Jackson2JsonRedisSerializer<DiaryInfoResponse> serializer = new Jackson2JsonRedisSerializer<>(objectMapper().constructType(new TypeReference<PageImpl<DiaryInfoResponse>>(){}));
+        serializer.setObjectMapper(objectMapper());
+
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig() // 레디스 캐시 설정
+                .disableCachingNullValues()
+                .entryTtl(Duration.ofHours(1)) // 캐시 데이터 유효기간 설정
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())) // 키 직렬화
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer(objectMapper()))); // 데이터 직렬화
+
+        Map<String, RedisCacheConfiguration> configurations = new HashMap<>();  // 캐시 이름 저장, 캐시를 설정할 수 있는 configuration 설정
+        configurations.put("refreshCache", defaultConfig.entryTtl(Duration.ofMinutes(30))); // 30분
+        configurations.put("diaryCache", defaultConfig.entryTtl(Duration.ofDays(1))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new DiaryCacheSerializer()))); // 30분
+        configurations.put("diaryPagingCache", defaultConfig.entryTtl(Duration.ofDays(1))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new DiaryPagingCacheSerializer()))); // 30분
+        configurations.put("memberCache", defaultConfig.entryTtl(Duration.ofDays(1))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new MemberCacheSerializer()))); // 30분
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory())
+                .cacheDefaults(defaultConfig)
+                .withInitialCacheConfigurations(configurations)
+                .build();
+    }
+}

--- a/src/main/java/com/sweep/jaksim31/config/cache/RedisInfo.java
+++ b/src/main/java/com/sweep/jaksim31/config/cache/RedisInfo.java
@@ -1,0 +1,22 @@
+package com.sweep.jaksim31.config.cache;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ConfigurationProperties(prefix = "redis")  // 설정 값을 불러올 때 prefix 값을 지정할 수 있다.
+@Configuration
+public class RedisInfo {
+    private String host;
+    private int port;
+    private RedisInfo master;
+    private List<RedisInfo> slaves;
+}
+


### PR DESCRIPTION
1. Github action workflow 수정
 * 기존 CI, CD 2개 job에서 CI, Report test result, SonarQube Analysis, CD 4개로 분리
 -> Pull request 시 action 작업시간 : 평균 5분30초 -> 3분

2. CacheConfig 환경 분리
  * LocalCacheConfig와 ProdCacheConfig 두개로 분리.
  -> LocalCache(Redis Standalone 구조), ProdCacheConfig (Master-Replica 구조)

3. Prod 환경 Application.yml 수정 
  * redirect url 수정 (localhost:3000 -> jaksim31.xyz)
  * DB 연결정보, 레디스 연결정보 수정
  * 추후 변경 가능성 있음